### PR TITLE
Nmap adapter modifications

### DIFF
--- a/tests/test_nmap_scan.py
+++ b/tests/test_nmap_scan.py
@@ -150,11 +150,9 @@ def test_get_port_info(xml_data, exp_protocol, exp_port, exp_service_name):
         assert service_name == exp_service_name
 
 
-def test_add_scans_to_addr():
+def test_add_scans_to_address():
     setup = Setup()
     scan = NMAPScan(setup.get_system())
-    scan._evidence = MagicMock()
-    scan._interface = setup.get_inspector()
 
     xml_data = """
     <host>
@@ -172,7 +170,7 @@ def test_add_scans_to_addr():
     device.new_address_(ip_addr)
     device / HTTP
 
-    scan.add_scans_to_addr(ip_addr, host)
+    scan.add_scans_to_address(ip_addr, host, setup.get_inspector(), MagicMock())
     assert len(device.entity.children) == 2
     http = device.entity.children[0]
     ssh = device.entity.children[1]
@@ -183,8 +181,6 @@ def test_add_scans_to_addr():
 def test_process_file():
     setup = Setup()
     scan = NMAPScan(setup.get_system())
-    scan._interface = setup.get_inspector()
-    scan._evidence = MagicMock()
 
     xml_data = """
     <nmaprun>
@@ -209,7 +205,7 @@ def test_process_file():
     device.new_address_(ip_addr)
     device / HTTP
 
-    scan.process_file(xml_data_bytes, "test.xml", scan._interface, source)
+    scan.process_file(xml_data_bytes, "test.xml", setup.get_inspector(), source)
 
     assert source.timestamp == datetime.fromtimestamp(1633024800)
     assert len(device.entity.children) == 2


### PR DESCRIPTION
**Firstly**, this pull request makes the nmap adapter's code pass mypy review with strict settings:
```
# mypy.ini
[mypy]
show_error_codes = True
strict = True
follow_imports = silent
disable_error_code = import-untyped
```
```bash
$ mypy tdsaf/adapters/nmap_scan.py 
Success: no issues found in 1 source file
```

**Secondly**, this pull request fixes an issue where nmap scan results are not applied at all if Wireshark captures are not processed beforehand.

This behavior can be observed when running the Deltaco Security Statement using TDSAF's main branch versus this branch:
```bash
# Statement
git clone https://github.com/testofthings/statement-deltaco-smart-outdoor-plug
git checkout statement-creation

# Sample data
git clone https://github.com/testofthings/sample-data
git checkout deltaco-smart-outdoor-plug

cd statement-deltaco-smart-outdoor-plug/
# create / activate venv here
python3 smart-outdoor-plug/statement.py -r ../sample-data/deltaco-smart-outdoor-plug/ -w
```

With TDSAF main (no data found for UDP port):
![Screenshot from 2025-01-09 11-01-52](https://github.com/user-attachments/assets/e4f8eea3-592d-4891-ace7-5ad9cb1e99b6)

With nmap branch:
![Screenshot from 2025-01-09 11-01-04](https://github.com/user-attachments/assets/955eac33-480d-4a32-9894-2f69303d66e8)

**Lastly**, this pull request adds tests for the nmap scan adapter.