### PR TITLE
Regression test running statements + GitHub action

### DIFF
--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -1,0 +1,31 @@
+name: Regression Test
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - toolsaf/**
+      - tests/**
+      - regression_tests/**
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -e .
+    - name: Run existing statements
+      run: |
+        python regression_tests/run_statements.py regression_tests/test_setup.json

--- a/regression_tests/.gitignore
+++ b/regression_tests/.gitignore
@@ -1,0 +1,1 @@
+statements

--- a/regression_tests/run_statements.py
+++ b/regression_tests/run_statements.py
@@ -8,6 +8,7 @@ from typing import Dict, Union, List
 
 FILE_PATH = Path(__file__)
 STATEMENTS_PATH = FILE_PATH.parent / "statements"
+GITHUB_SUMMARY = os.environ.get('GITHUB_STEP_SUMMARY', None)
 
 
 def read_setup(setup_file_path: Path) -> List[Dict[str, Union[str, List[str]]]]:
@@ -55,10 +56,36 @@ def run_statement(url: str, product: str) -> None:
             cwd=STATEMENTS_PATH
         )
         print(f"{dir_name} run passed")
+        if GITHUB_SUMMARY:
+            summarize_passed(dir_name)
     except subprocess.CalledProcessError as e:
         print(f"{dir_name} run failed! Error was:")
         print(e.stderr)
+        if GITHUB_SUMMARY:
+            summarize_failed(dir_name, str(e.stderr))
         sys.exit(1)
+
+
+def summarize_passed(statement: str) -> None:
+    add_to_summary(
+        f"### {statement}",
+        "Status: **Passed**"
+    )
+
+
+def summarize_failed(statement: str, error: str) -> None:
+    add_to_summary(
+        f"### {statement}",
+        "Status: **Failed**",
+        "Error was:",
+        f"```{error}```"
+    )
+
+
+def add_to_summary(*text: str) -> None:
+    with open(GITHUB_SUMMARY, 'a') as f:
+        for line in text:
+            print(line, file=f)
 
 
 def process_entry(entry: Dict[str, Union[str, List[str]]]) -> None:
@@ -71,6 +98,8 @@ def main(setup_file_path_str: str) -> None:
     """Perform test"""
     setup = read_setup(Path(setup_file_path_str))
     create_statements_dir()
+    if GITHUB_SUMMARY:
+        add_to_summary("# Test Summary:")
     for entry in setup:
         process_entry(entry)
 

--- a/regression_tests/run_statements.py
+++ b/regression_tests/run_statements.py
@@ -1,0 +1,83 @@
+import os
+import sys
+import json
+import subprocess
+from pathlib import Path
+from typing import Dict, Union, List
+
+
+FILE_PATH = Path(__file__)
+STATEMENTS_PATH = FILE_PATH.parent / "statements"
+
+
+def read_setup(setup_file_path: Path) -> List[Dict[str, Union[str, List[str]]]]:
+    """Read test setup json"""
+    with setup_file_path.open("rb") as file:
+        setup = json.load(file)
+    return setup["statements"]
+
+
+def create_statements_dir() -> None:
+    """Create directory for statements if it does not already exist"""
+    if not os.path.isdir(STATEMENTS_PATH):
+        print("Creating statements directory")
+        os.mkdir(STATEMENTS_PATH)
+
+
+def pull_or_clone_repository(url: str) -> None:
+    """Pull if already cloned; clone otherwise"""
+    repository_name = url.split("/")[-1]
+    repo_path = STATEMENTS_PATH / repository_name
+    if repo_path.exists():
+        print(f"Pulling latest {repository_name}")
+        subprocess.run(
+            ["git", "pull"],
+            check=True,
+            cwd=repo_path
+        )
+    else:
+        subprocess.run(
+            ["git", "clone", url],
+            check=True,
+            cwd=STATEMENTS_PATH
+        )
+
+
+def run_statement(url: str, product: str) -> None:
+    """Run statement, exit with error code on failure"""
+    dir_name = url.split("/")[-1]
+    try:
+        subprocess.run(
+            ["python", f"{dir_name}/{product}/statement.py"],
+            capture_output=True,
+            text=True,
+            check=True,
+            cwd=STATEMENTS_PATH
+        )
+        print(f"{dir_name} run passed")
+    except subprocess.CalledProcessError as e:
+        print(f"{dir_name} run failed! Error was:")
+        print(e.stderr)
+        sys.exit(1)
+
+
+def process_entry(entry: Dict[str, Union[str, List[str]]]) -> None:
+    """Process a single entry from the setup"""
+    pull_or_clone_repository(entry["url"])
+    run_statement(entry["url"], entry["product"])
+
+
+def main(setup_file_path_str: str) -> None:
+    """Perform test"""
+    setup = read_setup(Path(setup_file_path_str))
+    create_statements_dir()
+    for entry in setup:
+        process_entry(entry)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(f"Usage: python {FILE_PATH.name} <path_to_setup_json_file>")
+    else:
+        main(sys.argv[1])
+        sys.exit(0)

--- a/regression_tests/test_setup.json
+++ b/regression_tests/test_setup.json
@@ -1,0 +1,19 @@
+{
+    "statements": [
+        {
+            "url": "https://github.com/testofthings/statement-ruuvi",
+            "product": "ruuvi",
+            "data": []
+        },
+        {
+            "url": "https://github.com/testofthings/statement-deltaco-smart-outdoor-plug",
+            "product": "smart-outdoor-plug",
+            "data": []
+        },
+        {
+            "url": "https://github.com/testofthings/statement-IPC360",
+            "product": "ipc360",
+            "data": []
+        }
+    ]
+}


### PR DESCRIPTION
This pull request adds a regression test that clones/pulls the three public security statements and attempts to run them. It also adds a GitHub action that uses the script when pull requests are created.

The GitHub action also summarizes its results, you can see that here:
- [Pass](https://github.com/testofthings/toolsaf/actions/runs/13053059795)
- [Fail](https://github.com/testofthings/toolsaf/actions/runs/13052448356)

This is related to Issue #51.