### PR TITLE
Verdict Pass for certmitm results

### DIFF
--- a/tests/adapters/test_certmitm_reader.py
+++ b/tests/adapters/test_certmitm_reader.py
@@ -4,13 +4,13 @@ import zipfile
 from toolsaf.adapters.certmitm_reader import CertMITMReader
 from toolsaf.common.traffic import EvidenceSource
 from toolsaf.main import TLS
-from toolsaf.common.property import Properties
+from toolsaf.common.property import Properties, PropertyKey
 from toolsaf.common.verdict import Verdict
 from tests.test_model import Setup
 
 
-json_str = '{"client": "1.2.3.4","destination": { "ip": "10.10.10.10","port": 443}}\n{"client": "1.2.3.4","destination": { "ip": "11.11.11.11","port": 444}}'.encode("utf-8")
-json_str2 = '{"client": "5.6.7.8","destination": { "ip": "12.12.12.12","port": 443}}'.encode("utf-8")
+json_str =  '{"client": "1.2.3.4","destination": {"ip": "10.10.10.10","port": 443, "name": "BE1.com"}}\n{"client": "1.2.3.4","destination": { "ip": "11.11.11.11","port": 444, "name": "BE2.com"}}'.encode("utf-8")
+json_str2 = '{"client": "5.6.7.8","destination": {"ip": "12.12.12.12","port": 443, "name": "BE3.com"}}'.encode("utf-8")
 
 def test_process_file():
     zip_buffer = io.BytesIO()
@@ -19,7 +19,10 @@ def test_process_file():
         for file_name, data in ([
                                 ("1.2.3.4/data/data.txt", io.BytesIO(b'test')),
                                 ("1.2.3.4/errors.txt", io.BytesIO(json_str)),
-                                ("5.6.7.8/errors.txt", io.BytesIO(json_str2))]):
+                                ("5.6.7.8/errors.txt", io.BytesIO(json_str2)),
+                                ("certificates/BE1.com", io.BytesIO(b'test')),
+                                ("certificates/BE2.com", io.BytesIO(b'test')),
+                                ("certificates/BE3.com", io.BytesIO(b'test'))]):
             zip_file.writestr(file_name, data.getvalue())
 
     setup = Setup()
@@ -27,16 +30,16 @@ def test_process_file():
 
     device_1 = system.backend("D1").ip("1.2.3.4")
     device_2 = system.backend("D2").ip("5.6.7.8")
-    backend_1 = system.backend("BE1").ip("10.10.10.10")
-    backend_2 = system.backend("BE2").ip("11.11.11.11")
-    backend_3 = system.backend("BE3").ip("12.12.12.12")
+    backend_1 = system.backend("BE1").ip("10.10.10.10").dns("BE1.com")
+    backend_2 = system.backend("BE2").ip("11.11.11.11").dns("BE2.com")
+    backend_3 = system.backend("BE3").ip("12.12.12.12").dns("BE3.com")
 
     device_1 >> backend_1 / TLS             # Should fail
     device_1 >> backend_2 / TLS(port=444)   # Should fail
-    device_1 >> backend_3 / TLS
+    device_1 >> backend_3 / TLS             # Should pass
     device_2 >> backend_3 / TLS             # Should fail
 
-    reader = CertMITMReader(system)
+    reader = CertMITMReader(setup.get_system())
     source = EvidenceSource(name="")
     reader.process_file(zip_buffer, "", setup.get_inspector(), source)
 
@@ -48,6 +51,7 @@ def test_process_file():
         assert conn.source.name == expected_sources[i] and conn.target.parent.name == expected_targets[i]
         if conn.source.name == "D1" and conn.target.parent.name == "BE3":
             # No fail
-            assert len(conn.properties) == 0
+            assert conn.properties[PropertyKey("certmitm")].verdict == Verdict.PASS
         else:
             assert conn.properties[Properties.MITM].verdict == Verdict.FAIL
+

--- a/tests/adapters/test_certmitm_reader.py
+++ b/tests/adapters/test_certmitm_reader.py
@@ -53,5 +53,5 @@ def test_process_file():
             # No fail
             assert conn.properties[PropertyKey("certmitm")].verdict == Verdict.PASS
         else:
-            assert conn.properties[Properties.MITM].verdict == Verdict.FAIL
+            assert conn.properties[PropertyKey("certmitm")].verdict == Verdict.FAIL
 

--- a/toolsaf/adapters/certmitm_reader.py
+++ b/toolsaf/adapters/certmitm_reader.py
@@ -10,7 +10,7 @@ from toolsaf.core.event_interface import EventInterface, PropertyEvent
 from toolsaf.adapters.tools import SystemWideTool
 from toolsaf.core.model import IoTSystem, Host, Service
 from toolsaf.common.traffic import EvidenceSource, Evidence, IPFlow
-from toolsaf.common.property import Properties, PropertyKey
+from toolsaf.common.property import PropertyKey
 from toolsaf.common.verdict import Verdict
 
 
@@ -45,7 +45,7 @@ class CertMITMReader(SystemWideTool):
                 HWAddresses.NULL.data, connection_source, 0,
                 HWAddresses.NULL.data, target, int(port))
             flow.evidence = evidence
-            Properties.MITM.put_verdict(flow.properties, Verdict.FAIL)
+            PropertyKey("certmitm").put_verdict(flow.properties, Verdict.FAIL)
             interface.connection(flow)
 
         # Workaround for showing that certmitm was used
@@ -62,9 +62,9 @@ class CertMITMReader(SystemWideTool):
                         for endpoint_connection in endpoint.connections:
                             if not isinstance(endpoint_connection.target, Service):
                                 continue
+                            key = PropertyKey(self.tool_label)
                             if endpoint_connection.target.protocol == Protocol.TLS \
-                            and Properties.MITM not in endpoint_connection.properties:
-                                key = PropertyKey(self.tool_label)
+                            and key not in endpoint_connection.properties:
                                 ev = PropertyEvent(evidence, endpoint_connection, key.verdict(Verdict.PASS))
                                 interface.property_update(ev)
 


### PR DESCRIPTION
This pull requests adds the `Verdict.PASS` to TLS connections found based on domain names in certmitm's `certificates/` directory. `Verdict.PASS` will not be assigned to a connection that already has the property `PropertyKey("certmitm")` with a `Verdict.FAIL`.

This is related to Issue #62.