### PR TITLE
Show that nmap was used even when nothing was found

### DIFF
--- a/tests/adapters/test_nmap_scan.py
+++ b/tests/adapters/test_nmap_scan.py
@@ -177,7 +177,7 @@ def test_add_scans_to_address():
     assert http.properties.get(Properties.EXPECTED).verdict == Verdict.PASS
     assert ssh.properties.get(Properties.EXPECTED).verdict == Verdict.FAIL
     assert len(device.entity.properties) == 1
-    assert device.entity.properties.get(PropertyKey("nmap", "ok")) is None
+    assert device.entity.properties.get(PropertyKey("nmap")) is None
 
 
 def test_set_nothing_found():
@@ -190,7 +190,7 @@ def test_set_nothing_found():
 
     scan.set_nothing_found(ip_addr, setup.get_inspector(), MagicMock())
     assert len(device.entity.properties) == 2
-    assert device.entity.properties.get(PropertyKey("nmap", "ok")).verdict == Verdict.PASS
+    assert device.entity.properties.get(PropertyKey("nmap")).verdict == Verdict.PASS
 
 
 def test_add_scans_to_address_nothing_found():
@@ -213,7 +213,7 @@ def test_add_scans_to_address_nothing_found():
     scan.add_scans_to_address(ip_addr, host, setup.get_inspector(), MagicMock())
     assert len(device.entity.children) == 0
     assert len(device.entity.properties) == 2
-    assert device.entity.properties.get(PropertyKey("nmap", "ok")).verdict == Verdict.PASS
+    assert device.entity.properties.get(PropertyKey("nmap")).verdict == Verdict.PASS
 
 
 def test_process_file():

--- a/tests/adapters/test_nmap_scan.py
+++ b/tests/adapters/test_nmap_scan.py
@@ -8,7 +8,7 @@ from toolsaf.adapters.nmap_scan import NMAPScan
 from toolsaf.main import ConfigurationException, HTTP
 from toolsaf.common.address import Protocol, IPAddress, HWAddress
 from toolsaf.common.verdict import Verdict
-from toolsaf.common.property import Properties
+from toolsaf.common.property import Properties, PropertyKey
 from toolsaf.common.traffic import EvidenceSource
 from tests.test_model import Setup
 
@@ -176,6 +176,44 @@ def test_add_scans_to_address():
     ssh = device.entity.children[1]
     assert http.properties.get(Properties.EXPECTED).verdict == Verdict.PASS
     assert ssh.properties.get(Properties.EXPECTED).verdict == Verdict.FAIL
+    assert len(device.entity.properties) == 1
+    assert device.entity.properties.get(PropertyKey("nmap", "ok")) is None
+
+
+def test_set_nothing_found():
+    setup = Setup()
+    scan = NMAPScan(setup.get_system())
+
+    ip_addr = IPAddress.new("1.2.3.4")
+    device = setup.system.device("Test Device")
+    device.new_address_(ip_addr)
+
+    scan.set_nothing_found(ip_addr, setup.get_inspector(), MagicMock())
+    assert len(device.entity.properties) == 2
+    assert device.entity.properties.get(PropertyKey("nmap", "ok")).verdict == Verdict.PASS
+
+
+def test_add_scans_to_address_nothing_found():
+    setup = Setup()
+    scan = NMAPScan(setup.get_system())
+
+    xml_data = """
+    <host>
+        <ports>
+        </ports>
+    </host>
+    """
+    xml_data_bytes = BytesIO(xml_data.encode("utf-8"))
+    host = ElementTree.parse(xml_data_bytes).getroot()
+
+    ip_addr = IPAddress.new("1.2.3.4")
+    device = setup.system.device("Test Device")
+    device.new_address_(ip_addr)
+
+    scan.add_scans_to_address(ip_addr, host, setup.get_inspector(), MagicMock())
+    assert len(device.entity.children) == 0
+    assert len(device.entity.properties) == 2
+    assert device.entity.properties.get(PropertyKey("nmap", "ok")).verdict == Verdict.PASS
 
 
 def test_process_file():

--- a/toolsaf/adapters/nmap_scan.py
+++ b/toolsaf/adapters/nmap_scan.py
@@ -102,7 +102,7 @@ class NMAPScan(SystemWideTool):
         """Create property showing that no open ports were found but scan was run"""
         ev = PropertyAddressEvent(
             evidence, address,
-            PropertyKey(self.tool_label, "ok").verdict(Verdict.PASS, "No open ports found")
+            PropertyKey(self.tool_label).verdict(Verdict.PASS, "No open ports found")
         )
         interface.property_address_update(ev)
 


### PR DESCRIPTION
This pull request adds the property `nmap` with `Verdict.PASS` to nmap targets if nothing is found. This will show that nmap was used even when no open ports were found.

In the Toolsaf result output this looks like this:
```
[Expected/Pass]  Device
                 │  Addresses: Device
[Pass]           ├──nmap # No open ports found
```