### PR TITLE
Support and documentation for new returning None

### DIFF
--- a/documentation/architecture/Serialization.md
+++ b/documentation/architecture/Serialization.md
@@ -74,7 +74,7 @@ class AClassSerializer(Serializer[AClass]):
         self.config.map_simple_fields("a_string", "a_int")
 ```
 
-As seen, the serializer must tell `Serializer` which class instances it is 
+As seen, the serializer must tell `Serializer` which class instances it is
 serializing. Then it defines the simple fields which are 1:1 mapped into JSON fields.
 This is done through field `config` of the serializer.
 
@@ -121,8 +121,8 @@ method `new`.
         # Return new instance of the proper class
 ```
 
-Returning `None` allows to skip object and discarding the related JSON.
-This is handy if an object may becomes obsolete, and it can be omitted.
+Returning `None` allows you to skip the object and discard the related JSON.
+This is handy when an object may become obsolete and can be omitted.
 
 ### Serializing sub-objects
 

--- a/documentation/architecture/Serialization.md
+++ b/documentation/architecture/Serialization.md
@@ -117,9 +117,12 @@ If other constructors should be used, then serializer can implement
 method `new`.
 
 ```python
-    def new(self, stream: SerializerStream) -> AClass:
+    def new(self, stream: SerializerStream) -> Optional[AClass]:
         # Return new instance of the proper class
 ```
+
+Returning `None` allows to skip object and discarding the related JSON.
+This is handy if an object may becomes obsolete, and it can be omitted.
 
 ### Serializing sub-objects
 

--- a/toolsaf/common/serializer/serializer.py
+++ b/toolsaf/common/serializer/serializer.py
@@ -68,7 +68,9 @@ class SerializerStream:
                 serial.system = self.serializer.system
                 obj = serial.new(self)
                 if obj is None:
-                    raise ValueError(f"Serializer {serial} does not support new objects")
+                    # skip reading this object
+                    next_data = next(iterator, None)
+                    continue
             self._read_object(serial, obj)
             yield obj
             next_data = next(iterator, None)
@@ -292,8 +294,8 @@ class Serializer(SerializerBase, Generic[T]):
     def write(self, obj: T, stream: SerializerStream) -> None:
         """Custom write definitions"""
 
-    def new(self, _stream: SerializerStream) -> T:
-        """Create new object"""
+    def new(self, _stream: SerializerStream) -> Optional[T]:
+        """Create new object, return none if should skip"""
         obj = self.config.class_type()
         return cast(T, obj)
 


### PR DESCRIPTION
Support skipping object deserialization by returning None from new-method. Already used by requirement ministry.