### PR TITLE
Serialization extension

### DIFF
--- a/tests/serializers/test_model_serializer.py
+++ b/tests/serializers/test_model_serializer.py
@@ -1,3 +1,4 @@
+from toolsaf.main import HTTP
 from toolsaf.common.serializer.serializer import SerializerStream
 from toolsaf.core.components import Software
 from toolsaf.core.model import Connection, IoTSystem
@@ -7,13 +8,28 @@ from tests.test_model_new import Setup_1
 
 def test_simple_model():
     su = Setup_1()
+    su.system.online_resource("test-policy", url="example-url", keywords=["test", "policy"])
     su.system.finish_()  # creates SW components
     su.system.system.name = "Test"
     ser = IoTSystemSerializer(su.system.system)
     stream = SerializerStream(ser)
     js = list(stream.write(ser.system))
-    assert [j["type"] for j in js] == ["system", "host", "service", "sw", "host", "sw", "connection"]
-    assert js[0].items() >= {'id': 'id1', 'type': 'system', 'name': 'Test'}.items()
+    assert [j["type"] for j in js] == ["system", "host", "service", "sw", "host", "sw", "network", "connection", "online-resource"]
+
+    assert js[0] == {
+        "id": "id1",
+        "type": "system",
+        "name": "Test",
+        "long_name": "Test",
+        "description": "",
+        "match_priority": 0,
+        "address": "",
+        "host_type": "",
+        "status": "Expected",
+        "tag": "_",
+        "upload_tag": "_",
+    }
+
     assert js[1] == {
         'address': 'Device',
         'addresses': ['10:00:00:00:00:01|hw'],
@@ -25,11 +41,48 @@ def test_simple_model():
         'status': 'Expected',
         'tag': 'Device',
         'type': 'host',
+        "description": "Internet Of Things device",
+        "match_priority": 10,
     }
-    assert js[3].items() >= {'id': 'id4', 'at': 'id2', 'type': 'sw', 'name': 'Device 1 SW'}.items()
+
+    assert js[2] == {
+        "id": "id3",
+        "at": "id2",
+        "type": "service",
+        "name": "SSH:22",
+        "long_name": "Device 1 SSH:22",
+        "description": "",
+        "match_priority": 10,
+        "address": "Device/tcp:22",
+        "host_type": "",
+        "status": "Expected",
+        "tag": "Device/tcp:22",
+        "addresses": ["*/tcp:22"],
+    }
+
+    assert js[3] == {
+        "id": "id4",
+        "at": "id2",
+        "type": "sw",
+        "name": "Device 1 SW",
+        "long_name": "Device 1 SW",
+        "address": "Device&software=Device_1_SW",
+    }
+
     assert js[6] == {
+        "id": "id7",
+        "at": "id1",
+        "type": "network",
+        "name": "local",
+        #"type": "IPv4",
+        "address": "192.168.0.0/16",
+        #"hostmask": "0.0.255.255",
+        #"is_multicast": False,
+    }
+
+    assert js[7] == {
         'address': 'source=Device_2&target=Device/tcp:22',
-        'id': 'id7',
+        'id': 'id8',
         'at': 'id1',
         'long_name': 'some.local => Device 1 SSH:22',
         'name': 'SSH:22',
@@ -41,11 +94,22 @@ def test_simple_model():
         'target_long_name': 'Device 1 SSH:22',
     }
 
+    assert js[8] == {
+        "id": "id9",
+        "at": "id1",
+        "type": "online-resource",
+        "name": "test-policy",
+        "url": "example-url",
+        "keywords": ["test", "policy"],
+    }
+
     ser = IoTSystemSerializer(IoTSystem())
     stream = SerializerStream(ser)
     r = list(stream.read(js))
-    assert len(r) == 7
+    assert len(r) == 9
     assert isinstance(r[0], IoTSystem)
+    assert len(r[0].online_resources) == 1
+    assert len(r[0].networks) == 1
     assert r[0].name == "Test"
     assert len(r[0].children) == 2
     assert r[0].children[0].name == "Device 1"
@@ -53,7 +117,7 @@ def test_simple_model():
     assert len(r[0].children[0].children) == 1
     assert r[0].children[0].children[0].name == "SSH:22"
     assert r[0].children[1] == r[4]
-    assert isinstance(r[6], Connection)
-    assert r[6].source == r[4]
-    assert r[6].target == r[2]
+    assert isinstance(r[7], Connection)
+    assert r[7].source == r[4]
+    assert r[7].target == r[2]
     assert isinstance(r[3], Software)

--- a/tests/serializers/test_model_serializer.py
+++ b/tests/serializers/test_model_serializer.py
@@ -93,6 +93,11 @@ def test_simple_model():
         "tag": "Device/tcp:22",
         "addresses": ["*/tcp:22"],
         "properties": {},
+        "authentication": True,
+        "client_side": False,
+        "con_type": "Encrypted",
+        "protocol": "ssh",
+        "reply_from_other_address": False
     }
 
     assert js[3] == {

--- a/tests/serializers/test_model_serializer.py
+++ b/tests/serializers/test_model_serializer.py
@@ -331,7 +331,7 @@ def test_simple_model():
     ser = IoTSystemSerializer(su.system.system)
     stream = SerializerStream(ser)
     js = list(stream.write(ser.system))
-    assert [j["type"] for j in js] == ["system", "host", "service", "sw", "host", "sw", "network", "connection", "online-resource"]
+    assert [j["type"] for j in js] == ["system", "host", "service", "sw", "host", "sw", "network", "connection", "online-resource", "ignore-rules"]
 
     assert js[0] == {
         "id": "id1",
@@ -434,7 +434,7 @@ def test_simple_model():
     ser = IoTSystemSerializer(IoTSystem())
     stream = SerializerStream(ser)
     r = list(stream.read(js))
-    assert len(r) == 9
+    assert len(r) == 10
     assert isinstance(r[0], IoTSystem)
     assert len(r[0].online_resources) == 1
     assert len(r[0].networks) == 1

--- a/tests/serializers/test_model_serializer.py
+++ b/tests/serializers/test_model_serializer.py
@@ -102,6 +102,7 @@ def test_simple_model():
         "name": "Device 1 SW",
         "long_name": "Device 1 SW",
         "address": "Device&software=Device_1_SW",
+        "status": "Expected",
         "components": [
             {"name": "c1", "version": ""},
             {"name": "c2", "version": ""},

--- a/tests/serializers/test_model_serializer.py
+++ b/tests/serializers/test_model_serializer.py
@@ -41,6 +41,7 @@ def test_simple_model():
     su = Setup_1()
     su.system.online_resource("test-policy", url="example-url", keywords=["test", "policy"])
     su.device1.software().sbom(components=["c1", "c2"])
+    su.device1.ignore_name_requests("time.test.com", "time.test2.com")
     su.system.finish_()  # creates SW components
     su.system.system.name = "Test"
     ser = IoTSystemSerializer(su.system.system)
@@ -63,6 +64,8 @@ def test_simple_model():
         "properties": {},
     }
 
+    ignore_name_reqs = js[1].pop("ignore_name_requests")
+    assert "time.test.com" in ignore_name_reqs and "time.test2.com" in ignore_name_reqs
     assert js[1] == {
         'address': 'Device',
         'addresses': ['10:00:00:00:00:01|hw'],
@@ -76,8 +79,9 @@ def test_simple_model():
         'type': 'host',
         "description": "Internet Of Things device",
         "match_priority": 10,
-        "properties": {}
+        "properties": {},
     }
+    js[1]["ignore_name_requests"] = ["time.test.com", "time.test2.com"]
 
     assert js[2] == {
         "id": "id3",
@@ -160,6 +164,7 @@ def test_simple_model():
     assert r[0].children[0].name == "Device 1"
     assert len(r[1].components) == 1
     assert len(r[1].components[0].components) == 2
+    assert len(r[1].ignore_name_requests) == 2
     assert r[0].children[0] == r[1]
     assert len(r[0].children[0].children) == 1
     assert r[0].children[0].children[0].name == "SSH:22"

--- a/tests/serializers/test_model_serializer.py
+++ b/tests/serializers/test_model_serializer.py
@@ -1,11 +1,12 @@
 from unittest.mock import patch, MagicMock
 
 from toolsaf.main import HTTP, BLEAdvertisement
+from toolsaf.common.address import EntityTag
 from toolsaf.common.basics import Status, ConnectionType
 from toolsaf.common.verdict import Verdict
 from toolsaf.common.serializer.serializer import SerializerStream
 from toolsaf.core.components import Software, SoftwareComponent
-from toolsaf.core.model import Connection, IoTSystem, NodeComponent
+from toolsaf.core.model import Connection, IoTSystem, NodeComponent, Service
 from toolsaf.common.property import PropertyKey, PropertyVerdictValue, PropertySetValue
 from toolsaf.core.serializer.model_serializers import (
     IoTSystemSerializer, ServiceSerializer, ConnectionSerializer, NodeComponentSerializer, SoftwareSerializer
@@ -38,20 +39,17 @@ def test_service_serializer():
     serialized["type"] = "service"
 
     stream.resolve.return_value = device.entity
-
-    #with patch("toolsaf.core.serializer.model_serializers.Addresses.parse_address") as mock_parse_address:
-    #    mock_parse_address.return_value = service.parent
     new_service = list(stream.read([serialized]))[0]
 
+    assert isinstance(new_service, Service)
+    assert new_service.parent == device.entity
     assert new_service.name == service.name
     assert new_service.authentication == service.authentication
     assert new_service.client_side == service.client_side
     assert new_service.reply_from_other_address == service.reply_from_other_address
     assert new_service.protocol == service.protocol
     assert new_service.con_type == service.con_type
-
-    # FIXME:
-    #assert new_service.multicast_source == service.multicast_source
+    assert new_service.multicast_source == EntityTag("BLE_Ad")
 
     stream = SerializerStream(serializer)
     service = (device / HTTP).entity

--- a/tests/serializers/test_model_serializer.py
+++ b/tests/serializers/test_model_serializer.py
@@ -459,3 +459,5 @@ def test_simple_model():
     assert r[7].source == r[4]
     assert r[7].target == r[2]
     assert isinstance(r[3], Software)
+    assert r[7] in r[1].connections
+    assert r[7] in r[4].connections

--- a/tests/serializers/test_model_serializer.py
+++ b/tests/serializers/test_model_serializer.py
@@ -101,8 +101,7 @@ def test_addressable_serializer():
     serialized = stream.data
 
     assert serialized == {
-        "tag": "Device_1",
-        "addresses": ["10:00:00:00:00:01|hw"],
+        "addresses": ["Device_1", "10:00:00:00:00:01|hw"],
         "any_host": True
     }
 
@@ -344,7 +343,6 @@ def test_simple_model():
         "address": "",
         "host_type": "",
         "status": "Expected",
-        "tag": "_",
         "upload_tag": "_",
         "properties": {},
     }
@@ -353,14 +351,13 @@ def test_simple_model():
     assert "time.test.com" in ignore_name_reqs and "time.test2.com" in ignore_name_reqs
     assert js[1] == {
         'address': 'Device',
-        'addresses': ['10:00:00:00:00:01|hw'],
+        'addresses': ['Device', '10:00:00:00:00:01|hw'],
         'host_type': 'Device',
         'at': 'id1',
         'id': 'id2',
         'long_name': 'Device 1',
         'name': 'Device 1',
         'status': 'Expected',
-        'tag': 'Device',
         'type': 'host',
         "description": "Internet Of Things device",
         "match_priority": 10,
@@ -379,7 +376,6 @@ def test_simple_model():
         "address": "Device/tcp:22",
         "host_type": "",
         "status": "Expected",
-        "tag": "Device/tcp:22",
         "addresses": ["*/tcp:22"],
         "properties": {},
         "authentication": True,
@@ -408,10 +404,7 @@ def test_simple_model():
         "at": "id1",
         "type": "network",
         "name": "local",
-        #"type": "IPv4",
         "address": "192.168.0.0/16",
-        #"hostmask": "0.0.255.255",
-        #"is_multicast": False,
     }
 
     assert js[7] == {

--- a/tests/test_ignore_rules.py
+++ b/tests/test_ignore_rules.py
@@ -49,14 +49,15 @@ def test_at():
     system.ignore("test-type").at(device / SSH, device / TCP(1))
     rules = system.ignore_backend.get_rules()
     assert rules._current_rule.at == {
-        (device / SSH).entity, (device / TCP(1)).entity
+        (device / SSH).entity.get_system_address().get_parseable_value(),
+        (device / TCP(1)).entity.get_system_address().get_parseable_value()
     }
 
     software = device.software("Test SW").sw
     system.ignore("test-type").at(device.software("Test SW"))
     rules = system.ignore_backend.get_rules()
     assert rules._current_rule.at == {
-        software
+        software.get_system_address().get_parseable_value()
     }
 
 

--- a/toolsaf/builder_backend.py
+++ b/toolsaf/builder_backend.py
@@ -1121,6 +1121,7 @@ class SystemBackendRunner(SystemBackend):
         if args.dns:
             self.any().serve(DNS)
 
+        self.system.ignore_rules = self.ignore_backend.get_rules()
         if args.read_statement:
             # Ensure the system is empty
             assert len(self.system.get_hosts()) == 0, "System is not empty"
@@ -1144,7 +1145,7 @@ class SystemBackendRunner(SystemBackend):
 
         self.finish_()
 
-        registry = Registry(Inspector(self.system, self.ignore_backend.get_rules()))
+        registry = Registry(Inspector(self.system, self.system.ignore_rules))
 
         log_events = args.log_events
         if log_events:

--- a/toolsaf/builder_backend.py
+++ b/toolsaf/builder_backend.py
@@ -1090,7 +1090,8 @@ class SystemBackendRunner(SystemBackend):
                             help="Add default DNS server handling")
         parser.add_argument("-l", "--log", dest="log_level", choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
                             help="Set the logging level", default=None)
-        parser.add_argument("--write-statement", action="store_true", help="Dump JSON serialized security statement to stdout")
+        parser.add_argument("--write-statement", action="store_true",
+                            help="Dump JSON serialized security statement to stdout")
         parser.add_argument("-u", "--upload", action="store_true",
                             help="Upload statement. You can provide the path to your API key file with this flag.")
         parser.add_argument("--register-google", action="store_true",

--- a/toolsaf/builder_backend.py
+++ b/toolsaf/builder_backend.py
@@ -1129,8 +1129,6 @@ class SystemBackendRunner(SystemBackend):
 
             # Read serialized security statement
             json_path = cast(pathlib.Path, args.read_statement)
-            assert json_path.exists(), f"File {json_path} does not exist"
-            assert json_path.is_file(), f"File {json_path} is not a file"
 
             print(f"Reading security statement from {json_path}")
             json_data = json.loads(json_path.read_text())

--- a/toolsaf/builder_backend.py
+++ b/toolsaf/builder_backend.py
@@ -1135,8 +1135,6 @@ class SystemBackendRunner(SystemBackend):
             json_data = json.loads(json_path.read_text())
             serializer_version = list(json_data.keys())[0]
 
-            # FIXME: Remove events / sources from data before serialization
-
             # Deserialize the security statement
             serializer = IoTSystemSerializer(self.system)
             stream = SerializerStream(serializer)

--- a/toolsaf/builder_backend.py
+++ b/toolsaf/builder_backend.py
@@ -1090,7 +1090,7 @@ class SystemBackendRunner(SystemBackend):
                             help="Add default DNS server handling")
         parser.add_argument("-l", "--log", dest="log_level", choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
                             help="Set the logging level", default=None)
-        parser.add_argument("--statement-json", action="store_true", help="Dump security statement JSON to stdout")
+        parser.add_argument("--write-statement", action="store_true", help="Dump JSON serialized security statement to stdout")
         parser.add_argument("-u", "--upload", action="store_true",
                             help="Upload statement. You can provide the path to your API key file with this flag.")
         parser.add_argument("--register-google", action="store_true",
@@ -1156,7 +1156,7 @@ class SystemBackendRunner(SystemBackend):
 
         load_data = LoadedData(self.system, registry.logging, batch_import.batch_data)
 
-        if args.statement_json:
+        if args.write_statement:
             # dump security statement JSON
             ser = IoTSystemSerializer(self.system)
             stream = SerializerStream(ser)

--- a/toolsaf/builder_backend.py
+++ b/toolsaf/builder_backend.py
@@ -1158,18 +1158,21 @@ class SystemBackendRunner(SystemBackend):
         load_data = LoadedData(self.system, registry.logging, batch_import.batch_data)
 
         if args.write_statement:
+            serializer_version = "1.0"
+            json_dump: Dict[str, List[Any]] = {serializer_version: []}
             # dump security statement JSON
             ser = IoTSystemSerializer(self.system)
             stream = SerializerStream(ser)
             for js in stream.write(self.system):
-                print(json.dumps(js, indent=4))
+                json_dump[serializer_version].append(js)
             # dump events, if any
             if registry.logging.logs:
                 log_ser = EventSerializer(self.system)
                 stream = SerializerStream(log_ser, context=stream.context)
                 for log in registry.logging.logs:
                     for js in log_ser.write_event(log.event, stream):
-                        print(json.dumps(js, indent=4))
+                        json_dump[serializer_version].append(js)
+            print(json.dumps(json_dump, indent=4))
         else:
             with_files = bool(args.with_files)
             report = Report(registry)

--- a/toolsaf/builder_backend.py
+++ b/toolsaf/builder_backend.py
@@ -1090,7 +1090,7 @@ class SystemBackendRunner(SystemBackend):
                             help="Add default DNS server handling")
         parser.add_argument("-l", "--log", dest="log_level", choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
                             help="Set the logging level", default=None)
-        parser.add_argument("--write-statement", action="store_true",
+        parser.add_argument("-W", "--write-statement", action="store_true",
                             help="Dump JSON serialized security statement to stdout")
         parser.add_argument("-R", "--read-statement", type=pathlib.Path,
                             help="Read JSON serialized security statement from file. Use only with Toolsaf main.py")

--- a/toolsaf/common/address.py
+++ b/toolsaf/common/address.py
@@ -235,7 +235,7 @@ class Addresses:
         if address.startswith("*/"): # wildcard address
             address = address.replace("*/", "")
             if ":" not in address:
-                protocol, port = address, -1
+                protocol, port = address, "-1"
             else:
                 protocol, port = address.split(":")
             return EndpointAddress(

--- a/toolsaf/common/address.py
+++ b/toolsaf/common/address.py
@@ -263,7 +263,14 @@ class Addresses:
     def parse_endpoint(cls, value: str) -> AnyAddress:
         """Parse address or endpoint"""
         a, _, p = value.partition("/")
-        addr = cls.parse_address(a)
+        addr: AnyAddress
+        match a:
+            case "*":
+                addr = Addresses.ANY
+            case "BLE_Ad" if p.startswith("ble:"):  # a bit ugly match
+                addr = Addresses.BLE_Ad
+            case _:
+                addr = cls.parse_address(a)
         if p == "":
             return addr
         prot, _, port = p.partition(":")

--- a/toolsaf/common/address.py
+++ b/toolsaf/common/address.py
@@ -232,6 +232,17 @@ class Addresses:
     @classmethod
     def parse_address(cls, address: str) -> AnyAddress:
         """Parse any address type from string, type given as 'address|type'"""
+        if address.startswith("*/"): # wildcard address
+            address = address.replace("*/", "")
+            if ":" not in address:
+                protocol, port = address, -1
+            else:
+                protocol, port = address.split(":")
+            return EndpointAddress(
+                host=PseudoAddress(name="*", wildcard=True),
+                protocol=Protocol.get_protocol(protocol),
+                port=int(port)
+            )
         v, _, t = address.rpartition("|")
         if v == "" and t:
             # no type given

--- a/toolsaf/common/property.py
+++ b/toolsaf/common/property.py
@@ -190,7 +190,7 @@ class PropertyKey:
         if isinstance(old, PropertySetValue):
             v = old.sub_keys.copy()
             v.update(value.sub_keys)
-            properties[self] = v
+            properties[self] = PropertySetValue(v, explanation=value.explanation)
         elif isinstance(old, PropertyVerdictValue) and old.verdict == Verdict.IGNORE:
             # ignore is sticky
             return

--- a/toolsaf/core/ignore_rules.py
+++ b/toolsaf/core/ignore_rules.py
@@ -12,7 +12,7 @@ class IgnoreRule:
     """Data class representing a single rule"""
     file_type: str
     properties: Set[PropertyKey]
-    at: Set[Entity]
+    at: Set[str]
     explanation: str=""
 
     def __repr__(self) -> str:
@@ -41,7 +41,7 @@ class IgnoreRules:
     def at(self, location: Entity) -> None:
         """Set location to which the rules apply to"""
         assert self._current_rule, "Call ignore() first"
-        self._current_rule.at.add(location)
+        self._current_rule.at.add(location.get_system_address().get_parseable_value())
 
     def because(self, explanation: str) -> None:
         """Give reason for the ignore rule"""
@@ -51,8 +51,9 @@ class IgnoreRules:
     def update_based_on_rules(self, file_type: str, key: PropertyKey,
             verdict_value: PropertyVerdictValue, at: Entity) -> PropertyVerdictValue:
         """Update given propertys verdict and explanation at given location"""
+        at_address = at.get_system_address().get_parseable_value()
         for rule in self.rules.get(file_type, []):
-            if (key in rule.properties or not rule.properties) and (not rule.at or at in rule.at):
+            if (key in rule.properties or not rule.properties) and (not rule.at or at_address in rule.at):
                 new_pvv = PropertyVerdictValue(
                     Verdict.IGNORE, explanation=rule.explanation if rule.explanation else verdict_value.explanation
                 )

--- a/toolsaf/core/model.py
+++ b/toolsaf/core/model.py
@@ -14,6 +14,7 @@ from toolsaf.common.property import PropertyKey
 from toolsaf.common.traffic import Flow, EvidenceSource
 from toolsaf.common.verdict import Verdict
 from toolsaf.core.online_resources import OnlineResource
+from toolsaf.core.ignore_rules import IgnoreRules
 
 
 class Connection(Entity):
@@ -585,6 +586,9 @@ class IoTSystem(NetworkNode):
 
         # Tag used to identify uploaded security statements
         self.upload_tag: Optional[str] = None
+
+        # Include IgnoreRules in the model
+        self.ignore_rules = IgnoreRules()
 
     # NOTE: get_children() does not return connections
 

--- a/toolsaf/core/serializer/event_serializers.py
+++ b/toolsaf/core/serializer/event_serializers.py
@@ -358,8 +358,12 @@ class PropertyEventSerializer(Serializer[PropertyEvent]):
         KeyValueSerializer.write_key_value(obj, stream)
 
     def new(self, stream: SerializerStream) -> PropertyEvent:
-        address = Addresses.parse_system_address(stream["address"])
-        entity = self.system.find_endpoint(address)
+        if stream["address"] == "":
+            # Special handling for system entity
+            entity = self.system
+        else:
+            address = Addresses.parse_system_address(stream["address"])
+            entity = self.system.find_endpoint(address)
         assert isinstance(entity, Entity), "Did not find an entity"
         return PropertyEvent(
             EventSerializer.read_evidence(stream),

--- a/toolsaf/core/serializer/event_serializers.py
+++ b/toolsaf/core/serializer/event_serializers.py
@@ -358,6 +358,7 @@ class PropertyEventSerializer(Serializer[PropertyEvent]):
         KeyValueSerializer.write_key_value(obj, stream)
 
     def new(self, stream: SerializerStream) -> PropertyEvent:
+        entity: Optional[Union[Entity, Addressable, IoTSystem]] = None
         if stream["address"] == "":
             # Special handling for system entity
             entity = self.system

--- a/toolsaf/core/serializer/model_serializers.py
+++ b/toolsaf/core/serializer/model_serializers.py
@@ -137,8 +137,8 @@ class NetworkSerializer(Serializer[Network]):
             stream += "address", obj.ip_network.exploded
 
     def new(self, stream: SerializerStream) -> Network:
-        if "address" not in stream:
-            ip_network = ipaddress.ip_network(stream["address"])
+        if (address := stream - "address"):
+            ip_network = ipaddress.ip_network(address)
         else:
             ip_network = None
         return Network(stream["name"], ip_network)
@@ -174,6 +174,9 @@ class AddressableSerializer(Serializer[Addressable]):
         ads = stream.get("addresses") or []
         for a in ads:
             obj.addresses.add(Addresses.parse_address(a))
+        any_host = stream - "any_host"
+        if any_host:
+            obj.any_host = any_host
 
 
 class HostSerializer(Serializer[Host]):

--- a/toolsaf/core/serializer/model_serializers.py
+++ b/toolsaf/core/serializer/model_serializers.py
@@ -8,7 +8,7 @@ from toolsaf.common.basics import HostType
 from toolsaf.common.entity import Entity
 from toolsaf.common.verdict import Verdict
 from toolsaf.core.model import Addressable, Connection, Host, IoTSystem, NetworkNode, NodeComponent, Service
-from toolsaf.core.components import Software
+from toolsaf.core.components import Software, SoftwareComponent
 from toolsaf.core.online_resources import OnlineResource
 from toolsaf.common.serializer.serializer import Serializer, SerializerBase, SerializerStream
 
@@ -214,8 +214,24 @@ class SoftwareSerializer(SerializerBase):
     def __init__(self) -> None:
         super().__init__(class_type=Software)
 
+    def write(self, obj: Software, stream: SerializerStream) -> None:
+        components = []
+        for name, component in obj.components.items():
+            components.append({
+                "name": name,
+                "version": component.version
+            })
+        stream += "components", components
+
     def new(self, stream: SerializerStream) -> Software:
         parent = stream.resolve("at", of_type=NetworkNode)
         software = Software(parent, stream["name"])
         parent.add_component(software)
         return software
+
+    def read(self, obj: Software, stream: SerializerStream) -> None:
+        # Read software components
+        for component in stream["components"]:
+            name = component["name"]
+            version = component["version"]
+            obj.components[name] = SoftwareComponent(name, version)

--- a/toolsaf/core/serializer/model_serializers.py
+++ b/toolsaf/core/serializer/model_serializers.py
@@ -283,7 +283,8 @@ class SoftwareSerializer(SerializerBase):
         components = []
         for name, component in obj.components.items():
             components.append({
-                "name": name,
+                "key": name,
+                "component-name": component.name,
                 "version": component.version
             })
         stream += "components", components
@@ -296,6 +297,7 @@ class SoftwareSerializer(SerializerBase):
 
     def read(self, obj: Software, stream: SerializerStream) -> None:
         for component in stream["components"]:
-            name = component["name"]
+            key = component["key"]
+            name = component["component-name"]
             version = component["version"]
-            obj.components[name] = SoftwareComponent(name, version)
+            obj.components[key] = SoftwareComponent(name, version)

--- a/toolsaf/core/serializer/model_serializers.py
+++ b/toolsaf/core/serializer/model_serializers.py
@@ -43,6 +43,9 @@ class IoTSystemSerializer(Serializer[IoTSystem]):
         for online_resource in obj.online_resources:
             stream.push_object(online_resource, at_object=obj)
 
+    def read(self, obj: IoTSystem, stream: SerializerStream) -> None:
+        obj.upload_tag = stream - "upload_tag"
+
 
 class OnlineResourceSerializer(Serializer[OnlineResource]):
     """Serializer for online resources"""

--- a/toolsaf/core/serializer/model_serializers.py
+++ b/toolsaf/core/serializer/model_serializers.py
@@ -104,15 +104,15 @@ class NetworkNodeSerializer(Serializer[NetworkNode]):
         }
 
     def read(self, obj: NetworkNode, stream: SerializerStream) -> None:
-        obj.name = stream - "name"
-        obj.description = stream - "description"
-        obj.match_priority = int(stream - "match_priority")
+        obj.name = stream ["name"]
+        obj.description = stream["description"]
+        obj.match_priority = int(stream["match_priority"])
         # long_name is not an actual property, but a function
         obj.host_type = HostType(stream["host_type"])
-        obj.status = Status(stream - "status")
+        obj.status = Status(stream["status"])
 
-        if stream.get("external_activity"):
-            obj.external_activity = ExternalActivity(int(stream - "external_activity"))
+        if "external_activity" in stream:
+            obj.external_activity = ExternalActivity(int(stream ["external_activity"]))
 
         # Properties
         for key, value in cast(Dict[str, Dict[str, Any]], stream["properties"]).items():

--- a/toolsaf/core/serializer/model_serializers.py
+++ b/toolsaf/core/serializer/model_serializers.py
@@ -65,12 +65,20 @@ class NetworkNodeSerializer(Serializer[NetworkNode]):
         self.root = root
         self.config.abstract = True  # abstract class
         self.config.map_simple_fields("name")
+        self.config.map_simple_fields("description")
+        self.config.map_simple_fields("match_priority")
 
     def write(self, obj: NetworkNode, stream: SerializerStream) -> None:
+        # Following parameters are not serialized:
+        # concept_name
         stream += "address", obj.get_system_address().get_parseable_value()
         stream += "long_name", obj.long_name()
         stream += "host_type", obj.host_type.value
         stream += "status", obj.status.value
+
+        # What needs to be serialized?
+            # properties
+
         expected = obj.get_expected_verdict(None)
         if expected:
             stream += "expected", expected.value  # fail or pass

--- a/toolsaf/core/serializer/model_serializers.py
+++ b/toolsaf/core/serializer/model_serializers.py
@@ -230,8 +230,14 @@ class NodeComponentSerializer(Serializer[NodeComponent]):
         self.config.map_simple_fields("name")
 
     def write(self, obj: NodeComponent, stream: SerializerStream) -> None:
+        # Following parameters are not serialized:
+        # sub_components, status, tag
+        stream += "status", obj.status.value
         stream += "address", obj.get_system_address().get_parseable_value()
         stream += "long_name", obj.long_name()
+
+    def read(self, obj: NodeComponent, stream: SerializerStream) -> None:
+        obj.status = Status(stream["status"])
 
 
 class SoftwareSerializer(SerializerBase):

--- a/toolsaf/core/serializer/model_serializers.py
+++ b/toolsaf/core/serializer/model_serializers.py
@@ -124,6 +124,9 @@ class NetworkNodeSerializer(Serializer[NetworkNode]):
                 sub_keys = {PropertyKey.parse(k) for k in value["set"]}
                 obj.properties[property_key] = PropertySetValue(sub_keys, explanation)
 
+        if not isinstance(obj, IoTSystem):
+            obj.get_system().originals.add(obj)
+
 
 class NetworkSerializer(Serializer[Network]):
     """Serializer for Network"""
@@ -264,7 +267,7 @@ class ConnectionSerializer(Serializer[Connection]):
 
     def read(self, obj: Connection, stream: SerializerStream) -> None:
         obj.status = Status(stream["status"])
-
+        obj.source.get_system().originals.add(obj)
 
 
 class NodeComponentSerializer(Serializer[NodeComponent]):

--- a/toolsaf/core/serializer/model_serializers.py
+++ b/toolsaf/core/serializer/model_serializers.py
@@ -252,11 +252,17 @@ class ConnectionSerializer(Serializer[Connection]):
         stream += "long_name", obj.long_name()
 
     def new(self, stream: SerializerStream) -> Connection:
-        return Connection(stream.resolve("source", of_type=Addressable),
-                          stream.resolve("target", of_type=Addressable))
+        connection = Connection(
+            stream.resolve("source", of_type=Addressable),
+            stream.resolve("target", of_type=Addressable)
+        )
+        connection.source.get_parent_host().connections.append(connection)
+        connection.target.get_parent_host().connections.append(connection)
+        return connection
 
     def read(self, obj: Connection, stream: SerializerStream) -> None:
         obj.status = Status(stream["status"])
+
 
 
 class NodeComponentSerializer(Serializer[NodeComponent]):

--- a/toolsaf/core/serializer/model_serializers.py
+++ b/toolsaf/core/serializer/model_serializers.py
@@ -395,6 +395,8 @@ class SoftwareSerializer(SerializerBase):
                 "version": component.version
             })
         stream += "components", components
+        if obj.permissions:
+            stream += "permissions", list(obj.permissions)
 
     def new(self, stream: SerializerStream) -> Software:
         parent = stream.resolve("at", of_type=NetworkNode)
@@ -408,3 +410,7 @@ class SoftwareSerializer(SerializerBase):
             name = component["component-name"]
             version = component["version"]
             obj.components[key] = SoftwareComponent(name, version)
+        if (permissions := stream - "permissions"):
+            for permission in permissions:
+                obj.permissions.add(permission)
+                obj.properties[PropertyKey.create(("permission", permission))] = PropertyVerdictValue(Verdict.INCON)

--- a/toolsaf/core/serializer/model_serializers.py
+++ b/toolsaf/core/serializer/model_serializers.py
@@ -68,7 +68,7 @@ class IgnoreRulesSerializer(Serializer[IgnoreRules]):
                 rules[file_type].append(
                     {
                         "properties": [p.get_name() for p in rule.properties],
-                        "at": [entity.get_system_address().get_parseable_value() for entity in rule.at],
+                        "at": list(rule.at),
                         "explanation": rule.explanation
                     }
                 )
@@ -87,7 +87,7 @@ class IgnoreRulesSerializer(Serializer[IgnoreRules]):
                 obj.rules[file_type] += [IgnoreRule(
                     file_type=file_type,
                     properties={PropertyKey.parse(p) for p in rule["properties"]},
-                    at={Addresses.parse_system_address(at) for at in rule["at"]}, # type: ignore[misc]
+                    at=set(rule["at"]),
                     explanation=rule["explanation"]
                 )]
 

--- a/toolsaf/core/serializer/model_serializers.py
+++ b/toolsaf/core/serializer/model_serializers.py
@@ -13,6 +13,7 @@ from toolsaf.core.components import Software, SoftwareComponent, Cookies, Cookie
 from toolsaf.core.online_resources import OnlineResource
 from toolsaf.core.ignore_rules import IgnoreRules, IgnoreRule
 from toolsaf.common.serializer.serializer import Serializer, SerializerBase, SerializerStream
+from toolsaf.core.services import DHCPService, DNSService
 
 
 class IoTSystemSerializer(Serializer[IoTSystem]):
@@ -28,6 +29,8 @@ class IoTSystemSerializer(Serializer[IoTSystem]):
         self.config.map_class("network", NetworkSerializer())
         self.config.map_class("addressable", AddressableSerializer())
         self.config.map_class("host", HostSerializer())
+        self.config.map_class("dhcp-service", DHCPServiceSerializer())
+        self.config.map_class("dns-service", DNSServiceSerializer())
         self.config.map_class("service", ServiceSerializer())
         self.config.map_class("connection", ConnectionSerializer())
         self.config.map_class("component", NodeComponentSerializer())
@@ -273,6 +276,24 @@ class ServiceSerializer(Serializer[Service]):
             obj.protocol = Protocol(protocol)
         if (multicast_source := stream - "multicast_source"):
             obj.multicast_source = Addresses.parse_address(multicast_source)
+
+
+class DHCPServiceSerializer(Serializer[DHCPService]):
+    """Serializer for DHCP service"""
+    def __init__(self) -> None:
+        super().__init__(DHCPService)
+
+    def new(self, stream: SerializerStream) -> DHCPService:
+        return DHCPService(stream.resolve("at", of_type=Host), stream["name"])
+
+
+class DNSServiceSerializer(Serializer[DNSService]):
+    """Serializer for DNS service"""
+    def __init__(self) -> None:
+        super().__init__(DNSService)
+
+    def new(self, stream: SerializerStream) -> DNSService:
+        return DNSService(stream.resolve("at", of_type=Host), stream["name"])
 
 
 class ConnectionSerializer(Serializer[Connection]):

--- a/toolsaf/core/serializer/model_serializers.py
+++ b/toolsaf/core/serializer/model_serializers.py
@@ -107,11 +107,15 @@ class NetworkSerializer(Serializer[Network]):
         super().__init__(Network)
         self.config.map_simple_fields("name")
 
-    def write(self, obj, stream):
-        stream += "address", obj.ip_network.exploded
+    def write(self, obj: Network, stream: SerializerStream) -> None:
+        if obj.ip_network:
+            stream += "address", obj.ip_network.exploded
 
     def new(self, stream: SerializerStream) -> Network:
-        ip_network = ipaddress.ip_network(stream["address"])
+        if "address" not in stream:
+            ip_network = ipaddress.ip_network(stream["address"])
+        else:
+            ip_network = None
         return Network(stream["name"], ip_network)
 
     def read(self, obj: Network, stream: SerializerStream) -> None:

--- a/toolsaf/core/serializer/model_serializers.py
+++ b/toolsaf/core/serializer/model_serializers.py
@@ -243,6 +243,7 @@ class ConnectionSerializer(Serializer[Connection]):
         stream += "target", stream.id_for(obj.target)
         stream += "source_long_name", obj.source.long_name()
         stream += "target_long_name", obj.target.long_name()
+        stream += "status", obj.status.value
 
         s_tag, d_tag = obj.source.get_tag(), obj.target.get_tag()
         if s_tag and d_tag:
@@ -254,6 +255,9 @@ class ConnectionSerializer(Serializer[Connection]):
     def new(self, stream: SerializerStream) -> Connection:
         return Connection(stream.resolve("source", of_type=Addressable),
                           stream.resolve("target", of_type=Addressable))
+
+    def read(self, obj: Connection, stream: SerializerStream) -> None:
+        obj.status = Status(stream["status"])
 
 
 class NodeComponentSerializer(Serializer[NodeComponent]):

--- a/toolsaf/core/serializer/model_serializers.py
+++ b/toolsaf/core/serializer/model_serializers.py
@@ -218,15 +218,11 @@ class ServiceSerializer(Serializer[Service]):
         return Service(stream["name"], stream.resolve("at", of_type=Host))
 
     def read(self, obj: Service, stream: SerializerStream) -> None:
-        obj.authentication = stream["authentication"]
-        obj.client_side = stream["client_side"]
-        obj.reply_from_other_address = stream["reply_from_other_address"]
         obj.con_type = stream["con_type"]
-
-        if "protocol" in stream:
-            obj.protocol = Protocol(stream["protocol"])
-        if "multicast_source" in stream:
-            obj.multicast_source = Addresses.parse_address(stream["multicast_source"])
+        if (protocol := stream - "protocol"):
+            obj.protocol = Protocol(protocol)
+        if (multicast_source := stream - "multicast_source"):
+            obj.multicast_source = Addresses.parse_address(multicast_source)
 
 
 class ConnectionSerializer(Serializer[Connection]):

--- a/toolsaf/core/serializer/model_serializers.py
+++ b/toolsaf/core/serializer/model_serializers.py
@@ -215,4 +215,7 @@ class SoftwareSerializer(SerializerBase):
         super().__init__(class_type=Software)
 
     def new(self, stream: SerializerStream) -> Software:
-        return Software(stream.resolve("at", of_type=NetworkNode), stream["name"])
+        parent = stream.resolve("at", of_type=NetworkNode)
+        software = Software(parent, stream["name"])
+        parent.add_component(software)
+        return software

--- a/toolsaf/core/serializer/model_serializers.py
+++ b/toolsaf/core/serializer/model_serializers.py
@@ -179,7 +179,7 @@ class AddressableSerializer(Serializer[Addressable]):
             obj.addresses.add(EntityTag.new(tag))
         ads = stream.get("addresses") or []
         for a in ads:
-            obj.addresses.add(Addresses.parse_address(a))
+            obj.addresses.add(Addresses.parse_endpoint(a))
         any_host = stream - "any_host"
         if any_host:
             obj.any_host = any_host


### PR DESCRIPTION
Extend serialization and deserialization to cover more aspects of the security statement.

Updated command line arguments:
``` 
product/statement.py --write-statement <filename>
toolsaf/main.py --read-statement <filename>
```

**NOTE:**
When running the Ruuvi statement from JSON and reading data results differ based on what address parser is used in `AddressableSerializer`.

If `AddressableSerializer.read` uses `Addresses.parse_endpoint()` to parse addresses the result shows way more red than if the following modifier version of  `Addresses.parse_address()` is used
```python
@classmethod
    def parse_address(cls, address: str) -> AnyAddress:
        """Parse any address type from string, type given as 'address|type'"""
        if address.startswith("*/"): # wildcard address
            address = address.replace("*/", "")
            if ":" not in address:
                protocol, port = address, "-1"
            else:
                protocol, port = address.split(":")
            return EndpointAddress(
                host=PseudoAddress(name="*", wildcard=True),
                protocol=Protocol.get_protocol(protocol),
                port=int(port)
            )
        v, _, t = address.rpartition("|")
        if v == "" and t:
            # no type given
            if t[0].isdigit():
                return IPAddress.new(t)  # if starts with digit it is IP
            if "/" in t: # Endpoint address   ## <====== THIS RIGHT HERE
                return cls.parse_endpoint(t)  ## <======
            return EntityTag(t)  # otherwise tag
        if t == "tag":
            return EntityTag(v)
        if t == "ip":
            return IPAddress.new(v)
        if t == "hw":
            return HWAddress.new(v)
        if t == "name":
            return DNSName(v)
        raise ValueError(f"Unknown address type '{t}', allowed are 'ip', 'hw', and 'name'")
```