### PR TITLE
Fix pypi license format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,8 @@ version         = "0.3.0"
 requires-python = ">=3.11"
 description     = "Tool-Driven Security Assessment Framework"
 readme          = "Info.md"
-license         = {text = "MIT License"}
+license         = "MIT"
+license-files = ["LICENSE"]
 authors         = [
     {name = "Rauli Kaksonen", email = "rauli.kaksonen@testofthings.com"}
 ]


### PR DESCRIPTION
Packet build had warnings about license format:

```
 * Getting build dependencies for wheel...
/tmp/build-env-qkhks8ev/lib/python3.11/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
!!
        ********************************************************************************
        Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).
        By 2026-Feb-18, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.
        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************
!!
```

Change the format in the .toml file according to the [documentation](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license)