### PR TITLE
Add missing package directories to setuptools configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,10 +47,12 @@ Issues          = "https://github.com/testofthings/toolsaf/issues"
 find = { where = ["."], include = [
         "toolsaf",
         "toolsaf.adapters",
+        "toolsaf.adapters.data",
         "toolsaf.common",
         "toolsaf.common.serializer",
         "toolsaf.core",
-        "toolsaf.core.serializer"
+        "toolsaf.core.serializer",
+        "toolsaf.diagram_visualizer"
 ] }
 
 [tool.setuptools.package-data]


### PR DESCRIPTION
The Toolsaf build produces these warnings:
```
**/tmp/build-env-skm965mj/lib/python3.12/site-packages/setuptools/command/build_py.py:212: _Warning: Package 'toolsaf.adapters.data' is absent from the `packages` configuration.
!!

        ********************************************************************************
        ############################
        # Package would be ignored #
        ############################
        Python recognizes 'toolsaf.adapters.data' as an importable package[^1],
        but it is absent from setuptools' `packages` configuration.

        This leads to an ambiguous overall configuration. If you want to distribute this
        package, please make sure that 'toolsaf.adapters.data' is explicitly added
        to the `packages` configuration field.

        Alternatively, you can also rely on setuptools' discovery methods
        (for example by using `find_namespace_packages(...)`/`find_namespace:`
        instead of `find_packages(...)`/`find:`).

        You can read more about "package discovery" on setuptools documentation page:

        - https://setuptools.pypa.io/en/latest/userguide/package_discovery.html

        If you don't want 'toolsaf.adapters.data' to be distributed and are
        already explicitly excluding 'toolsaf.adapters.data' via
        `find_namespace_packages(...)/find_namespace` or `find_packages(...)/find`,
        you can try to use `exclude_package_data`, or `include-package-data=False` in
        combination with a more fine grained `package-data` configuration.

        You can read more about "package data files" on setuptools documentation page:

        - https://setuptools.pypa.io/en/latest/userguide/datafiles.html


        [^1]: For Python, any directory (with suitable naming) can be imported,
              even if it does not contain any `.py` files.
              On the other hand, currently there is no concept of package data
              directory, all directories are treated like packages.
        ********************************************************************************

!!
  check.warn(importable)
**
```

This pull request addresses that by adding two missing packages to `pyproject.toml`