### PR TITLE
Allow dns() to accept multiple names

### DIFF
--- a/tests/test_dns.py
+++ b/tests/test_dns.py
@@ -1,5 +1,7 @@
+import pytest
 import pathlib
 
+from toolsaf.main import ConfigurationException
 from toolsaf.common.address import EntityTag, IPAddress, DNSName, Protocol
 from toolsaf.common.verdict import Verdict
 from toolsaf.builder_backend import SystemBackend
@@ -24,6 +26,23 @@ def test_dns():
 
     assert f1 == c1.connection
     assert dev1.entity.addresses == {EntityTag("Device"), IPAddress.new("1.0.0.1"), DNSName("name1.local")}
+
+
+def test_add_dns_names():
+    sb = SystemBackend()
+    dev1 = sb.device().dns("example.com").dns("example.org")
+    assert DNSName("example.com") in dev1.entity.addresses
+    assert DNSName("example.org") in dev1.entity.addresses
+
+    dev2 = sb.device().dns("test.com", "test.org")
+    assert DNSName("test.com") in dev2.entity.addresses
+    assert DNSName("test.org") in dev2.entity.addresses
+
+    with pytest.raises(ConfigurationException, match=r"Using name many times: test\.com"):
+        sb.device().dns("test.com")
+
+    with pytest.raises(ValueError, match=r"Invalid DNS label in name: '-incorrect_domain\.com'"):
+        sb.device().dns("-incorrect_domain.com")
 
 
 def test_dns_pcap():

--- a/toolsaf/builder_backend.py
+++ b/toolsaf/builder_backend.py
@@ -247,17 +247,18 @@ class NodeBackend(NodeBuilder, NodeManipulator):
             self.dns(name)
         return self
 
-    def dns(self, name: str) -> Self:
-        name = name.strip()
-        DNSName.validate(name)
-        dn = DNSName(name)
-        networks = self.entity.get_networks_for(dn)
-        assert len(networks) == 1, "DNS name must be in one network"
-        self.entity.addresses.add(dn)
-        key = AddressAtNetwork(dn, networks[0])
-        if key in self.system.entity_by_address:
-            raise ConfigurationException(f"Using name many times: {dn}")
-        self.system.entity_by_address[key] = self
+    def dns(self, *names: str) -> Self:
+        for name in names:
+            name = name.strip()
+            DNSName.validate(name)
+            dn = DNSName(name)
+            networks = self.entity.get_networks_for(dn)
+            assert len(networks) == 1, "DNS name must be in one network"
+            self.entity.addresses.add(dn)
+            key = AddressAtNetwork(dn, networks[0])
+            if key in self.system.entity_by_address:
+                raise ConfigurationException(f"Using name many times: {dn}")
+            self.system.entity_by_address[key] = self
         return self
 
     def describe(self, text: str) -> Self:

--- a/toolsaf/main.py
+++ b/toolsaf/main.py
@@ -88,8 +88,8 @@ class NodeBuilder:
         """Define entity name, names with dot (.) are assumed to be DNS domain names"""
         raise NotImplementedError()
 
-    def dns(self, name: str) -> Self:
-        """Define DNS name"""
+    def dns(self, *names: str) -> Self:
+        """Define DNS names"""
         raise NotImplementedError()
 
     def describe(self, text: str) -> Self:


### PR DESCRIPTION
This PR adds the possibility to provide multiple DNS names with just one `dns()` call. Example:
```
system.device().dns("test.com", "test.org")
```