### PR TITLE
Add VSCode dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,25 @@
+FROM python:3.12-slim
+
+WORKDIR /workspace
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git \
+        nano \
+        openssh-client \
+        bash-completion \
+        locales \
+    && rm -rf /var/lib/apt/lists/* \
+    && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen \
+    && locale-gen en_US.UTF-8 \
+    && update-locale LANG=en_US.UTF-8
+
+# Add a non-root user and switch to it
+RUN useradd -m dev \
+    && mkdir -p /home/dev/.vscode-server /workspace/.venv \
+    && chown -R dev:dev /workspace /home/dev/.vscode-server /workspace/.venv
+
+USER dev
+
+ENV LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LC_ALL=en_US.UTF-8

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,51 @@
+{
+    "name": "Toolsaf Dev Container",
+    "dockerFile": "Dockerfile",
+    "remoteUser": "dev",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
+    "workspaceFolder": "/workspace",
+    "postCreateCommand": "python3 -m venv /workspace/.venv && /workspace/.venv/bin/pip install /workspace/.[dev]",
+    "containerEnv": {
+        "SHELL": "/bin/bash"
+    },
+    "mounts": [
+        "type=volume,target=/home/dev/.vscode-server",
+        "type=volume,target=/workspace/.venv"
+    ],
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-python.python",
+                "ms-python.pylint",
+                "ms-python.mypy-type-checker",
+                "eamodio.gitlens"
+            ],
+            "settings": {
+                "files.trimTrailingWhitespace": true,
+                "search.exclude": {"**/build": true, "**/.venv": true},
+                "python.analysis.exclude": [
+                    "**/build/**",
+                    "**/.venv/**"
+                ],
+                "[python]": {"editor.tabSize": 4},
+                "python.defaultInterpreterPath": "/workspace/.venv/bin/python",
+                "python.testing.pytestArgs": ["${workspaceFolder}/tests"],
+                "python.testing.unittestEnabled": false,
+                "python.testing.pytestEnabled": true,
+
+                "pylint.interpreter": ["/workspace/.venv/bin/python"],
+                "pylint.args": ["--rcfile=${workspaceFolder}/pyproject.toml", "disable=E0401"],
+                "pylint.ignorePatterns": ["**/tests/**", "tests/**"],
+                "pylint.cwd": "${workspaceFolder}",
+                "pylint.importStrategy": "fromEnvironment",
+                "pylint.severity": {"convention": "Error", "error": "Error", "fatal": "Error", "refactor": "Error", "warning": "Error", "W0611": "Error", "undefined-variable": "Error"},
+
+                "mypy-type-checker.interpreter": ["/workspace/.venv/bin/python"],
+                "mypy-type-checker.args": ["--config-file=${workspaceFolder}/pyproject.toml"],
+                "mypy-type-checker.ignorePatterns": ["**/tests/**", "tests/**"],
+                "mypy-type-checker.importStrategy": "fromEnvironment",
+                "mypy-type-checker.severity": {"note": "Error", "warning": "Error", "error": "Error"}
+            }
+        }
+    }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
     "remoteUser": "dev",
     "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
     "workspaceFolder": "/workspace",
-    "postCreateCommand": "python3 -m venv /workspace/.venv && /workspace/.venv/bin/pip install /workspace/.[dev]",
+    "postCreateCommand": "python3 -m venv /workspace/.venv && /workspace/.venv/bin/pip install -e /workspace/.[dev]",
     "containerEnv": {
         "SHELL": "/bin/bash"
     },
@@ -34,7 +34,7 @@
                 "python.testing.pytestEnabled": true,
 
                 "pylint.interpreter": ["/workspace/.venv/bin/python"],
-                "pylint.args": ["--rcfile=${workspaceFolder}/pyproject.toml", "disable=E0401"],
+                "pylint.args": ["--rcfile=${workspaceFolder}/pyproject.toml", "--disable=E0401"],
                 "pylint.ignorePatterns": ["**/tests/**", "tests/**"],
                 "pylint.cwd": "${workspaceFolder}",
                 "pylint.importStrategy": "fromEnvironment",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,13 +4,16 @@
     "remoteUser": "dev",
     "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
     "workspaceFolder": "/workspace",
+    "initializeCommand": "mkdir -p statement-files statement-data",
     "postCreateCommand": "python3 -m venv /workspace/.venv && /workspace/.venv/bin/pip install -e /workspace/.[dev]",
     "containerEnv": {
         "SHELL": "/bin/bash"
     },
     "mounts": [
         "type=volume,target=/home/dev/.vscode-server",
-        "type=volume,target=/workspace/.venv"
+        "type=volume,target=/workspace/.venv",
+        "type=bind,source=${localWorkspaceFolder}/statement-files,target=/workspace/statement-files",
+        "type=bind,source=${localWorkspaceFolder}/statement-data,target=/workspace/statement-data"
     ],
     "customizations": {
         "vscode": {

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ wheels/
 .toolsaf*
 
 shodan/
+statement-files/
+statement-data/


### PR DESCRIPTION
This PR adds the possibility to develop Toolsaf from inside a VSCode dev container.

**EDIT**: I have updated the dev container to create two host mounts. These being `statement-files` and `statement-data`. Statement Python files and tool data can be placed into these directories. This allows you to run statements in the dev container. Requires a rebuild to test.

Closes Issue #165.