### PR TITLE
DSL tracking and serialization

### DIFF
--- a/tests/test_change_tracking.py
+++ b/tests/test_change_tracking.py
@@ -105,12 +105,16 @@ def test_add_connection():
 
 def test_modify_system_network():
     sb = SystemBackend()
-    network = sb.network("10.42.0.0/16").network
+    network = sb.network(ip_mask="10.42.0.0/16").network
 
     assert len(sb._changes) == 1
     assert network in sb._changes
 
-    # TODO: Add serialization test when network serialization is supported
+    serialized = sb.serialize_statement_changes()
+    assert len(serialized) == 1
+    assert serialized[0]["type"] == "network"
+    assert serialized[0]["name"] == "local"
+    assert serialized[0]["address"] == "network=10.42.0.0/16"
 
 
 def test_add_mobile_permissions():

--- a/tests/test_change_tracking.py
+++ b/tests/test_change_tracking.py
@@ -6,6 +6,21 @@ from toolsaf.common.android import LOCATION, NETWORK
 from toolsaf.common.basics import HostType
 
 
+def test_self_changed():
+    sb = SystemBackend(name="Test System")
+    assert len(sb._changes) == 0
+
+    sb.self_changed()
+    assert len(sb._changes) == 1
+    assert sb.system in sb._changes
+
+    serialized = sb.serialize_statement_changes()
+    assert len(serialized) == 1
+    assert serialized[0]["type"] == "system"
+    assert serialized[0]["name"] == "Test System"
+    assert serialized[0]["address"] == ""
+
+
 def test_add_hosts():
     sb = SystemBackend()
     entities = [

--- a/tests/test_change_tracking.py
+++ b/tests/test_change_tracking.py
@@ -1,0 +1,197 @@
+from toolsaf.builder_backend import SystemBackend
+from toolsaf.main import TLS, HTTP, TCP, ARP, IP, UDP
+from toolsaf.common.android import LOCATION, NETWORK
+
+
+def test_add_hosts():
+    sb = SystemBackend()
+    entities = [
+        sb.device("Test Device").entity,
+        sb.backend("Test Backend").entity,
+        sb.mobile("Test Mobile").entity,
+        sb.browser("Test Browser").entity,
+        sb.infra("Test Infra").entity,
+        sb.any("Test Any Host").entity
+    ]
+
+    assert len(sb._changes) == len(entities)
+    for entity in entities:
+        assert entity in sb._changes
+
+
+def test_add_host_with_serve_and_dns():
+    sb = SystemBackend()
+    host = sb.device("Test Device")
+    sb._changes = set()
+
+    host.serve(TLS, HTTP).dns("example.com", "example.org")
+    assert len(sb._changes) == 3
+    assert host.entity in sb._changes               # DNS names added
+    assert host.entity.children[0] in sb._changes   # TLS and HTTP service added
+    assert host.entity.children[1] in sb._changes
+
+
+def test_add_connection():
+    sb = SystemBackend()
+    dev1 = sb.device("Test Device 1")
+    dev2 = sb.device("Test Device 2")
+    sb._changes = set()
+
+    con = dev1 >> dev2 / TCP(123)
+    assert len(sb._changes) == 2
+    assert con.connection in sb._changes            # Connection added
+    assert dev2.entity.children[0] in sb._changes   # TCP service added
+
+
+def test_modify_system_network():
+    sb = SystemBackend()
+    network = sb.network("10.42.0.0/16").network
+
+    assert len(sb._changes) == 1
+    assert network in sb._changes
+
+
+def test_add_mobile_permissions():
+    sb = SystemBackend()
+    mobile = sb.mobile("Test Mobile")
+    sb._changes = set()
+
+    mobile.set_permissions(NETWORK, LOCATION)
+    assert len(sb._changes) == 1
+    assert mobile.entity.components[0] in sb._changes # Software modified
+
+
+def test_add_arp_to_host():
+    sb = SystemBackend()
+    dev = sb.device("Test Device")
+    sb._changes = set()
+
+    arp = dev / ARP
+    assert len(sb._changes) == 4
+    assert arp.entity in sb._changes                # ARP service added
+    assert dev.entity.connections[0] in sb._changes # Connection from device ARP service to broadcast ARP service
+    sb._changes.remove(arp.entity)
+    sb._changes.remove(dev.entity.connections[0])
+
+    rest_of_changes = {"ff_ff_ff_ff_ff_ff", "ff_ff_ff_ff_ff_ff/arp"}
+    for entry in sb._changes:
+        sys_addr = entry.get_system_address().get_parseable_value()
+        assert sys_addr in rest_of_changes          # Broadcast ARP stuff
+        rest_of_changes.remove(sys_addr)
+
+
+def test_add_connection_with_udp_port_range():
+    sb = SystemBackend()
+    dev1 = sb.device("Test Device 1")
+    dev2 = sb.device("Test Device 2")
+    sb._changes = set()
+
+    con = dev1 >> dev2 / UDP().port_range(1000, 2000)
+    assert len(sb._changes) == 2
+    assert con.connection in sb._changes            # Connection added
+    assert dev2.entity.children[0] in sb._changes   # UDP service added
+
+
+def test_add_udp_broadcast():
+    sb = SystemBackend()
+    broadcast = sb.any("Broadcast")
+    mob = sb.mobile("Test Mobile")
+    sb._changes = set()
+
+    con = mob >> broadcast / UDP(port=1234).broadcast()
+    assert len(sb._changes) == 2
+    assert con.connection in sb._changes
+    assert broadcast.entity.children[0] in sb._changes  # Service added
+
+
+def test_add_ip_multicast():
+    sb = SystemBackend()
+    mob = sb.mobile("Test Mobile")
+    any_host = sb.any("Any Host")
+    sb._changes = set()
+
+    igmp = any_host / IP(protocol=2).multicast("230.0.0.1")
+    con = mob >> igmp
+    assert len(sb._changes) == 2
+    assert igmp.entity in sb._changes
+    assert con.connection in sb._changes
+
+
+def test_add_udp_multicast():
+    sb = SystemBackend()
+    any_host = sb.any("Any Host")
+    mob = sb.mobile("Test Mobile")
+    sb._changes = set()
+
+    mdns = (any_host / UDP(port=1234).multicast("224.0.0.251")).name("mDNS")
+    con = mob >> mdns
+    assert len(sb._changes) == 2
+    assert mdns.entity in sb._changes
+    assert con.connection in sb._changes
+
+
+def test_add_sbom():
+    sb = SystemBackend()
+    dev = sb.device("Test Device")
+    sb._changes = set()
+
+    dev.software().sbom(["sw1", "sw2"])
+    assert len(sb._changes) == 1
+    assert dev.entity.components[0] in sb._changes  # Software modified
+
+
+def test_add_ignore_rules():
+    sb = SystemBackend()
+    sb.ignore(file_type="testssl").properties(
+        "testssl:cert_expirationStatus <hostCert#1>"
+    ).because("Testing")
+
+    assert len(sb._changes) == 1
+    assert sb.system in sb._changes
+
+
+def test_add_ignore_name_request():
+    sb = SystemBackend()
+    dev = sb.device("Test Device")
+    sb._changes = set()
+
+    dev.ignore_name_requests("example.com")
+    assert len(sb._changes) == 1
+    assert dev.entity in sb._changes
+
+
+def test_add_ip_address():
+    sb = SystemBackend()
+    dev = sb.device("Test Device")
+    sb._changes = set()
+
+    dev.ip("10.42.1.1")
+    assert len(sb._changes) == 1
+    assert dev.entity in sb._changes
+
+
+def test_add_hw_address():
+    sb = SystemBackend()
+    dev = sb.device("Test Device")
+    sb._changes = set()
+
+    dev.hw("aa:bb:cc:dd:ee:ff")
+    assert len(sb._changes) == 1
+    assert dev.entity in sb._changes
+
+
+def test_add_properties():
+    sb = SystemBackend()
+    dev = sb.device("Test Device")
+    sb._changes = set()
+
+    dev.set_property("test:abc")
+    assert len(sb._changes) == 1
+    assert dev.entity in sb._changes
+
+
+def test_add_online_resource():
+    sb = SystemBackend()
+    sb.online_resource("privacy-policy", url="example.com", keywords=["privacy", "policy"])
+    assert len(sb._changes) == 1
+    assert sb.system in sb._changes

--- a/tests/test_change_tracking.py
+++ b/tests/test_change_tracking.py
@@ -117,6 +117,13 @@ def test_modify_system_network():
     assert serialized[0]["address"] == "network=10.42.0.0/16"
 
 
+def test_non_local_network_not_serialized():
+    sb = SystemBackend()
+    sb.network("Subnet", ip_mask="10.42.0.0/16").network
+
+    assert len(sb._changes) == 0
+
+
 def test_add_mobile_permissions():
     sb = SystemBackend()
     mobile = sb.mobile("Test Mobile")

--- a/tests/test_change_tracking.py
+++ b/tests/test_change_tracking.py
@@ -1,6 +1,9 @@
+import pytest
+
 from toolsaf.builder_backend import SystemBackend
 from toolsaf.main import TLS, HTTP, TCP, ARP, IP, UDP
 from toolsaf.common.android import LOCATION, NETWORK
+from toolsaf.common.basics import HostType
 
 
 def test_add_hosts():
@@ -18,6 +21,26 @@ def test_add_hosts():
     for entity in entities:
         assert entity in sb._changes
 
+    serialized = sb.serialize_statement_changes()
+    assert len(serialized) == len(entities)
+    assert {
+        "address": "Test_Device",
+        "addresses": ["Test_Device"],
+        "any_host": False,
+        "description": "Internet Of Things device",
+        "external_activity": 1,
+        "host_type": HostType.DEVICE,
+        "ignore_name_requests": [],
+        "long_name": "Test Device",
+        "match_priority": 10,
+        "name": "Test Device",
+        "parent_address": "",
+        "properties": {},
+        "status": "Expected",
+        "type": "host",
+        "verdict": "Incon",
+    } in serialized
+
 
 def test_add_host_with_serve_and_dns():
     sb = SystemBackend()
@@ -29,6 +52,25 @@ def test_add_host_with_serve_and_dns():
     assert host.entity in sb._changes               # DNS names added
     assert host.entity.children[0] in sb._changes   # TLS and HTTP service added
     assert host.entity.children[1] in sb._changes
+
+    serialized = sb.serialize_statement_changes()
+    assert len(serialized) == 3
+    for entry in serialized:
+        match entry:
+            case {"type": "host"}:
+                assert entry["address"] == "Test_Device"
+                assert "example.org|name" in entry["addresses"]
+                assert "example.com|name" in entry["addresses"]
+                assert "Test_Device" in entry["addresses"]
+
+            case {"type": "service", "name": "TLS:443"}:
+                assert entry["address"] == "Test_Device/tcp:443"
+
+            case {"type": "service", "name": "HTTP:80"}:
+                assert entry["address"] == "Test_Device/tcp:80"
+
+            case _:
+                pytest.fail("Unexpected entry in serialized changes")
 
 
 def test_add_connection():
@@ -42,6 +84,24 @@ def test_add_connection():
     assert con.connection in sb._changes            # Connection added
     assert dev2.entity.children[0] in sb._changes   # TCP service added
 
+    serialized = sb.serialize_statement_changes()
+    assert len(serialized) == 2
+    for entry in serialized:
+        match entry:
+            case {"type": "connection"}:
+                assert entry["name"] == "TCP:123"
+                assert entry["source_address"] == "Test_Device_1"
+                assert entry["target_address"] == "Test_Device_2/tcp:123"
+                assert entry["address"] == "source=Test_Device_1&target=Test_Device_2/tcp:123"
+
+            case {"type": "service"}:
+                assert entry["name"] == "TCP:123"
+                assert entry["address"] == "Test_Device_2/tcp:123"
+                assert entry["parent_address"] == "Test_Device_2"
+
+            case _:
+                pytest.fail("Unexpected entry in serialized changes")
+
 
 def test_modify_system_network():
     sb = SystemBackend()
@@ -49,6 +109,8 @@ def test_modify_system_network():
 
     assert len(sb._changes) == 1
     assert network in sb._changes
+
+    # TODO: Add serialization test when network serialization is supported
 
 
 def test_add_mobile_permissions():
@@ -60,6 +122,14 @@ def test_add_mobile_permissions():
     assert len(sb._changes) == 1
     assert mobile.entity.components[0] in sb._changes # Software modified
 
+    serialized = sb.serialize_statement_changes()
+    assert len(serialized) == 1
+    assert serialized[0]["type"] == "sw"
+    assert NETWORK.value in serialized[0]["permissions"]
+    assert LOCATION.value in serialized[0]["permissions"]
+    assert serialized[0]["address"] == "Test_Mobile&software=Test_Mobile_SW"
+    assert serialized[0]["parent_address"] == "Test_Mobile"
+
 
 def test_add_arp_to_host():
     sb = SystemBackend()
@@ -70,14 +140,33 @@ def test_add_arp_to_host():
     assert len(sb._changes) == 4
     assert arp.entity in sb._changes                # ARP service added
     assert dev.entity.connections[0] in sb._changes # Connection from device ARP service to broadcast ARP service
-    sb._changes.remove(arp.entity)
-    sb._changes.remove(dev.entity.connections[0])
 
-    rest_of_changes = {"ff_ff_ff_ff_ff_ff", "ff_ff_ff_ff_ff_ff/arp"}
-    for entry in sb._changes:
-        sys_addr = entry.get_system_address().get_parseable_value()
-        assert sys_addr in rest_of_changes          # Broadcast ARP stuff
-        rest_of_changes.remove(sys_addr)
+    serialized = sb.serialize_statement_changes()
+    assert len(serialized) == 4
+
+    for entry in serialized:
+        match entry:
+            case {"type": "host"}:
+                assert entry["address"] == "ff_ff_ff_ff_ff_ff"
+                assert entry["name"] == "ff:ff:ff:ff:ff:ff"
+                assert entry["parent_address"] == ""
+
+            case {"type": "connection"}:
+                assert entry["name"] == "ARP"
+                assert entry["source_address"] == "Test_Device/arp"
+                assert entry["target_address"] == "ff_ff_ff_ff_ff_ff/arp"
+                assert entry["address"] == "source=Test_Device/arp&target=ff_ff_ff_ff_ff_ff/arp"
+
+            case {"type": "service", "address": "ff_ff_ff_ff_ff_ff/arp"}:
+                assert entry["name"] == "ARP"
+                assert entry["parent_address"] == "ff_ff_ff_ff_ff_ff"
+
+            case {"type": "service", "address": "Test_Device/arp"}:
+                assert entry["name"] == "ARP"
+                assert entry["parent_address"] == "Test_Device"
+
+            case _:
+                pytest.fail("Unexpected entry in serialized changes")
 
 
 def test_add_connection_with_udp_port_range():
@@ -91,6 +180,25 @@ def test_add_connection_with_udp_port_range():
     assert con.connection in sb._changes            # Connection added
     assert dev2.entity.children[0] in sb._changes   # UDP service added
 
+    serialized = sb.serialize_statement_changes()
+    assert len(serialized) == 2
+    for entry in serialized:
+        match entry:
+            case {"type": "connection"}:
+                assert entry["name"] == "UDP:1000-2000"
+                assert entry["source_address"] == "Test_Device_1"
+                assert entry["target_address"] == "Test_Device_2/udp:1000"
+                assert entry["address"] == "source=Test_Device_1&target=Test_Device_2/udp:1000"
+
+            case {"type": "service"}:
+                assert entry["name"] == "UDP:1000-2000"
+                assert entry["address"] == "Test_Device_2/udp:1000"
+                assert entry["parent_address"] == "Test_Device_2"
+                assert entry["port_range"] =="1000-2000"
+
+            case _:
+                pytest.fail("Unexpected entry in serialized changes")
+
 
 def test_add_udp_broadcast():
     sb = SystemBackend()
@@ -102,6 +210,24 @@ def test_add_udp_broadcast():
     assert len(sb._changes) == 2
     assert con.connection in sb._changes
     assert broadcast.entity.children[0] in sb._changes  # Service added
+
+    serialized = sb.serialize_statement_changes()
+    assert len(serialized) == 2
+    for entry in serialized:
+        match entry:
+            case {"type": "connection"}:
+                assert entry["name"] == "UDP:1234 255.255.255.255"
+                assert entry["source_address"] == "Test_Mobile"
+                assert entry["target_address"] == "Broadcast/udp:1234"
+                assert entry["address"] == "source=Test_Mobile&target=Broadcast/udp:1234"
+
+            case {"type": "service"}:
+                assert entry["address"] == "Broadcast/udp:1234"
+                assert entry["parent_address"] == "Broadcast"
+                assert entry["multicast_target"] == "255.255.255.255"
+
+            case _:
+                pytest.fail("Unexpected entry in serialized changes")
 
 
 def test_add_ip_multicast():
@@ -116,6 +242,22 @@ def test_add_ip_multicast():
     assert igmp.entity in sb._changes
     assert con.connection in sb._changes
 
+    serialized = sb.serialize_statement_changes()
+    assert len(serialized) == 2
+    for entry in serialized:
+        match entry:
+            case {"type": "connection"}:
+                assert entry["name"] == "IP:2 230.0.0.1"
+                assert entry["source_address"] == "Test_Mobile"
+                assert entry["target_address"] == "Any_Host/ip:2"
+                assert entry["address"] == "source=Test_Mobile&target=Any_Host/ip:2"
+
+            case {"type": "service"}:
+                assert entry["name"] == "IP:2 230.0.0.1"
+                assert entry["address"] == "Any_Host/ip:2"
+                assert entry["parent_address"] == "Any_Host"
+                assert entry["protocol"] == "" # This IP(protocol=2) is not reflected here, just pointing that out
+
 
 def test_add_udp_multicast():
     sb = SystemBackend()
@@ -129,6 +271,22 @@ def test_add_udp_multicast():
     assert mdns.entity in sb._changes
     assert con.connection in sb._changes
 
+    serialized = sb.serialize_statement_changes()
+    assert len(serialized) == 2
+    for entry in serialized:
+        match entry:
+            case {"type": "connection"}:
+                assert entry["name"] == "mDNS"
+                assert entry["source_address"] == "Test_Mobile"
+                assert entry["target_address"] == "Any_Host/udp:1234"
+                assert entry["address"] == "source=Test_Mobile&target=Any_Host/udp:1234"
+
+            case {"type": "service"}:
+                assert entry["name"] == "mDNS"
+                assert entry["address"] == "Any_Host/udp:1234"
+                assert entry["parent_address"] == "Any_Host"
+                assert entry["multicast_target"] == "224.0.0.251"
+
 
 def test_add_sbom():
     sb = SystemBackend()
@@ -139,9 +297,26 @@ def test_add_sbom():
     assert len(sb._changes) == 1
     assert dev.entity.components[0] in sb._changes  # Software modified
 
+    serialized = sb.serialize_statement_changes()
+    assert len(serialized) == 1
+    assert serialized[0]["type"] == "sw"
+    assert {
+        "key": "sw1",
+        "name": "sw1",
+        "version": "",
+    } in serialized[0]["components"]
+    assert {
+        "key": "sw2",
+        "name": "sw2",
+        "version": "",
+    } in serialized[0]["components"]
+    assert serialized[0]["address"] == "Test_Device&software=Test_Device_SW"
+    assert serialized[0]["parent_address"] == "Test_Device"
+
 
 def test_add_ignore_rules():
     sb = SystemBackend()
+    sb._changes = set()
     sb.ignore(file_type="testssl").properties(
         "testssl:cert_expirationStatus <hostCert#1>"
     ).because("Testing")
@@ -149,15 +324,36 @@ def test_add_ignore_rules():
     assert len(sb._changes) == 1
     assert sb.system in sb._changes
 
+    serialized = sb.serialize_statement_changes()
+    assert len(serialized) == 1
+    assert serialized[0]["type"] == "system"
+    assert serialized[0]["address"] == ""
+    assert serialized[0]["ignore_rules"] == {
+        "rules": {
+            "testssl": [{
+                "at": [],
+                "explanation": "Testing",
+                "properties": ["testssl:cert_expirationStatus <hostCert#1>"],
+            }]
+        }
+    }
+
 
 def test_add_ignore_name_request():
     sb = SystemBackend()
     dev = sb.device("Test Device")
     sb._changes = set()
 
-    dev.ignore_name_requests("example.com")
+    dev.ignore_name_requests("example.com", "example.org")
     assert len(sb._changes) == 1
     assert dev.entity in sb._changes
+
+    serialized = sb.serialize_statement_changes()
+    assert len(serialized) == 1
+    assert serialized[0]["type"] == "host"
+    assert serialized[0]["address"] == "Test_Device"
+    assert "example.com" in serialized[0]["ignore_name_requests"]
+    assert "example.org" in serialized[0]["ignore_name_requests"]
 
 
 def test_add_ip_address():
@@ -169,6 +365,12 @@ def test_add_ip_address():
     assert len(sb._changes) == 1
     assert dev.entity in sb._changes
 
+    serialized = sb.serialize_statement_changes()
+    assert len(serialized) == 1
+    assert serialized[0]["type"] == "host"
+    assert serialized[0]["address"] == "Test_Device"
+    assert "10.42.1.1" in serialized[0]["addresses"]
+
 
 def test_add_hw_address():
     sb = SystemBackend()
@@ -178,6 +380,12 @@ def test_add_hw_address():
     dev.hw("aa:bb:cc:dd:ee:ff")
     assert len(sb._changes) == 1
     assert dev.entity in sb._changes
+
+    serialized = sb.serialize_statement_changes()
+    assert len(serialized) == 1
+    assert serialized[0]["type"] == "host"
+    assert serialized[0]["address"] == "Test_Device"
+    assert "aa:bb:cc:dd:ee:ff|hw" in serialized[0]["addresses"]
 
 
 def test_add_properties():
@@ -189,9 +397,16 @@ def test_add_properties():
     assert len(sb._changes) == 1
     assert dev.entity in sb._changes
 
+    serialized = sb.serialize_statement_changes()
+    assert len(serialized) == 1
+    assert serialized[0]["type"] == "host"
+    assert serialized[0]["properties"] == {"test:abc": {"verdict": "Incon"}}
+
 
 def test_add_online_resource():
     sb = SystemBackend()
     sb.online_resource("privacy-policy", url="example.com", keywords=["privacy", "policy"])
     assert len(sb._changes) == 1
     assert sb.system in sb._changes
+
+    # TODO: Add serialization test when online resource serialization is supported

--- a/tests/test_change_tracking.py
+++ b/tests/test_change_tracking.py
@@ -269,6 +269,9 @@ def test_add_ip_multicast():
                 assert entry["parent_address"] == "Any_Host"
                 assert entry["protocol"] == "" # This IP(protocol=2) is not reflected here, just pointing that out
 
+            case _:
+                pytest.fail("Unexpected entry in serialized changes")
+
 
 def test_add_udp_multicast():
     sb = SystemBackend()
@@ -297,6 +300,9 @@ def test_add_udp_multicast():
                 assert entry["address"] == "Any_Host/udp:1234"
                 assert entry["parent_address"] == "Any_Host"
                 assert entry["multicast_target"] == "224.0.0.251"
+
+            case _:
+                pytest.fail("Unexpected entry in serialized changes")
 
 
 def test_add_sbom():

--- a/toolsaf/builder_backend.py
+++ b/toolsaf/builder_backend.py
@@ -153,6 +153,7 @@ class SystemBackend(SystemBuilder):
 
     def ignore(self, file_type: str) -> 'IgnoreRulesBackend':
         self.ignore_backend.new_rule(file_type)
+        self.system.ignore_rules = self.ignore_backend.get_rules()
         self.changed(self.system)
         return self.ignore_backend
 

--- a/toolsaf/builder_backend.py
+++ b/toolsaf/builder_backend.py
@@ -240,6 +240,10 @@ class SystemBackend(SystemBuilder):
         """Add entity to changed set"""
         self._changes.add(entity)
 
+    def self_changed(self) -> None:
+        """Add the system itself to changed set, use when initially creating the system"""
+        self._changes.add(self.system)
+
     def serialize_statement_changes(self) -> List[Dict[str, Any]]:
         """Serialize changes done to the statement then reset change tracker"""
         serializer = SystemSerializer()

--- a/toolsaf/builder_backend.py
+++ b/toolsaf/builder_backend.py
@@ -59,7 +59,7 @@ class SystemBackend(SystemBuilder):
         self.loaders: List[EvidenceLoader] = []
         self.protocols: Dict[Any, 'ProtocolBackend'] = {}
         self.ignore_backend = IgnoreRulesBackend()
-        self._changes: Set[Entity] = set()
+        self._changes: Set[Entity | Network] = set()
 
     def network(self, subnet: str="", ip_mask: Optional[str] = None) -> 'NetworkBuilder':
         if subnet:
@@ -68,6 +68,7 @@ class SystemBackend(SystemBuilder):
             nb = NetworkBackend(self)
         if ip_mask:
             nb.mask(ip_mask)
+        self.changed(nb.network)
         return nb
 
     def device(self, name: str="") -> 'HostBackend':
@@ -219,15 +220,16 @@ class SystemBackend(SystemBuilder):
             host_names.add(h.name)
             self._check_unique_under_parent(h)
 
-    def changed(self, entity: Entity) -> None:
+    def changed(self, entity: Entity | Network) -> None:
         """Add entity to changed set"""
         self._changes.add(entity)
 
-    def serialize_statement_changes(self) -> str:
-        """FIXME"""
+    def serialize_statement_changes(self) -> List[Dict[str, Any]]:
+        """Serialize changes done to the statement then reset change tracker"""
         serializer = SystemSerializer()
         result = serializer.serialize_set(self._changes)
-        print(json.dumps(result, indent=4))
+        self._changes = set()
+        return result
 
         # We want to have a authenticator related to each authenticated service
         # NOTE: Not ready to go into this level now...
@@ -460,7 +462,7 @@ class HostBackend(NodeBackend, HostBuilder):
     def __lshift__(self, multicast: MulticastConfigurer) -> ConnectionBuilder:
         target = self / multicast.protocol.multicast(multicast.address)
         c = multicast.source >> target
-        self.system.changed(c.connection)
+        self.system.changed(c.connection) # type: ignore[attr-defined]
         return c
 
     def cookies(self) -> 'CookieBackend':

--- a/toolsaf/builder_backend.py
+++ b/toolsaf/builder_backend.py
@@ -66,9 +66,9 @@ class SystemBackend(SystemBuilder):
             nb = NetworkBackend(self, subnet)
         else:
             nb = NetworkBackend(self)
+            self.changed(nb.network) # Track only local network for now
         if ip_mask:
             nb.mask(ip_mask)
-        self.changed(nb.network)
         return nb
 
     def device(self, name: str="") -> 'HostBackend':

--- a/toolsaf/builder_backend.py
+++ b/toolsaf/builder_backend.py
@@ -38,6 +38,7 @@ from toolsaf.core.result import Report
 from toolsaf.core.components import SoftwareComponent
 from toolsaf.core.services import DHCPService, DNSService
 from toolsaf.core.online_resources import OnlineResource
+from toolsaf.common.entity import Entity
 from toolsaf.common.verdict import Verdict
 from toolsaf.common.android import MobilePermissions
 from toolsaf.adapters.spdx_reader import SPDXJson
@@ -58,6 +59,7 @@ class SystemBackend(SystemBuilder):
         self.loaders: List[EvidenceLoader] = []
         self.protocols: Dict[Any, 'ProtocolBackend'] = {}
         self.ignore_backend = IgnoreRulesBackend()
+        self._changes: Set[Entity] = set()
 
     def network(self, subnet: str="", ip_mask: Optional[str] = None) -> 'NetworkBuilder':
         if subnet:
@@ -125,6 +127,7 @@ class SystemBackend(SystemBuilder):
         self.system.online_resources.append(
             OnlineResource(name, url, keywords)
         )
+        self.changed(self.system)
         return self
 
     def attach_file(self, file_path: str, relative_to: Optional[str] = None) -> Self:
@@ -149,6 +152,7 @@ class SystemBackend(SystemBuilder):
 
     def ignore(self, file_type: str) -> 'IgnoreRulesBackend':
         self.ignore_backend.new_rule(file_type)
+        self.changed(self.system)
         return self.ignore_backend
 
     def tag(self, tag: str) -> None:
@@ -168,6 +172,7 @@ class SystemBackend(SystemBuilder):
             h.description = description
             h.match_priority = 10
             hb = HostBackend(h, self)
+        self.changed(hb.entity)
         return hb
 
     def get_protocol_backend(self,
@@ -214,6 +219,16 @@ class SystemBackend(SystemBuilder):
             host_names.add(h.name)
             self._check_unique_under_parent(h)
 
+    def changed(self, entity: Entity) -> None:
+        """Add entity to changed set"""
+        self._changes.add(entity)
+
+    def serialize_statement_changes(self) -> str:
+        """FIXME"""
+        serializer = SystemSerializer()
+        result = serializer.serialize_set(self._changes)
+        print(json.dumps(result, indent=4))
+
         # We want to have a authenticator related to each authenticated service
         # NOTE: Not ready to go into this level now...
         # auth_map = DataUsage.map_authenticators(self.system, {})
@@ -259,6 +274,7 @@ class NodeBackend(NodeBuilder, NodeManipulator):
             if key in self.system.entity_by_address:
                 raise ConfigurationException(f"Using name many times: {dn}")
             self.system.entity_by_address[key] = self
+            self.system.changed(self.entity)
         return self
 
     def describe(self, text: str) -> Self:
@@ -283,6 +299,7 @@ class NodeBackend(NodeBuilder, NodeManipulator):
         if sb is None:
             sb = SoftwareBackend(self, name)
             self.sw[name] = sb
+        self.system.changed(sb.sw)
         return sb
 
     def __rshift__(self, target: ServiceOrGroup) -> 'ConnectionBackend':
@@ -305,6 +322,7 @@ class NodeBackend(NodeBuilder, NodeManipulator):
         if not networks:
             raise ConfigurationException(f"Address {address} not in any network range of {self.entity.name}")
         self.entity.addresses.add(address)
+        self.system.changed(self.entity)
         for nw in networks:
             key = AddressAtNetwork(address, nw)
             old = self.system.entity_by_address.get(key)
@@ -371,6 +389,7 @@ class ServiceBackend(NodeBackend, ServiceBuilder):
             e.status = Status.EXPECTED
         s.entity.get_parent_host().connections.append(c)
         self.entity.get_parent_host().connections.append(c)
+        self.system.changed(c)
         return ConnectionBackend(c, (s, self))
 
 
@@ -441,6 +460,7 @@ class HostBackend(NodeBackend, HostBuilder):
     def __lshift__(self, multicast: MulticastConfigurer) -> ConnectionBuilder:
         target = self / multicast.protocol.multicast(multicast.address)
         c = multicast.source >> target
+        self.system.changed(c.connection)
         return c
 
     def cookies(self) -> 'CookieBackend':
@@ -460,11 +480,13 @@ class HostBackend(NodeBackend, HostBuilder):
             n = n.strip()
             DNSName.validate(n)
             self.entity.ignore_name_requests.add(DNSName(n))
+        self.system.changed(self.entity)
         return self
 
     def set_property(self, *key: str) -> Self:
         p = PropertyKey.create(key).persistent()
         self.entity.set_property(p.verdict())  # inconclusive
+        self.system.changed(self.entity)
         return self
 
     def set_permissions(self, *permissions: MobilePermissions) -> Self:
@@ -679,8 +701,10 @@ class ProtocolBackend:
             self.transport, (self.service_port if self.port_to_name else -1)
         old = parent.service_builders.get(key)
         if old:
+            parent.system.changed(old.entity)
             return old
         b = self._create_service(parent)
+        parent.system.changed(b.entity)
         parent.service_builders[key] = b
         b.entity.status = Status.EXPECTED
         assert b.entity.parent == parent.entity

--- a/toolsaf/builder_backend.py
+++ b/toolsaf/builder_backend.py
@@ -221,17 +221,6 @@ class SystemBackend(SystemBuilder):
             host_names.add(h.name)
             self._check_unique_under_parent(h)
 
-    def changed(self, entity: Entity | Network) -> None:
-        """Add entity to changed set"""
-        self._changes.add(entity)
-
-    def serialize_statement_changes(self) -> List[Dict[str, Any]]:
-        """Serialize changes done to the statement then reset change tracker"""
-        serializer = SystemSerializer()
-        result = serializer.serialize_set(self._changes)
-        self._changes = set()
-        return result
-
         # We want to have a authenticator related to each authenticated service
         # NOTE: Not ready to go into this level now...
         # auth_map = DataUsage.map_authenticators(self.system, {})
@@ -246,6 +235,17 @@ class SystemBackend(SystemBuilder):
         #             exp = f"Authentication by {auth.name} (implicit)"
         #             prop_v = Properties.AUTHENTICATION_DATA.value(explanation=exp)
         #             prop_v[0].set(s.properties, prop_v[1])
+
+    def changed(self, entity: Entity | Network) -> None:
+        """Add entity to changed set"""
+        self._changes.add(entity)
+
+    def serialize_statement_changes(self) -> List[Dict[str, Any]]:
+        """Serialize changes done to the statement then reset change tracker"""
+        serializer = SystemSerializer()
+        result = serializer.serialize_set(self._changes)
+        self._changes = set()
+        return result
 
 
 class NodeBackend(NodeBuilder, NodeManipulator):

--- a/toolsaf/core/serializer/model_serializer.py
+++ b/toolsaf/core/serializer/model_serializer.py
@@ -1,6 +1,6 @@
 """Model (de)serialization"""
 from typing import (
-    Callable, Dict, Any, Optional, List, Annotated, Union, Literal
+    Callable, Dict, Any, Optional, List, Annotated, Union, Literal, Set
 )
 import logging
 import ipaddress
@@ -64,6 +64,19 @@ class SystemSerializer:
             result.append(serialized)
             if self._queue:
                 stack.extend(reversed(self._queue)) # Depth first
+        return result
+
+    def serialize_set(self, obj_set: Set[Any]):
+        """FIXME"""
+        result = []
+        for obj in obj_set:
+            if not (serializer := self.serializer_map.get(type(obj))):
+                LOGGER.debug("No serializer found for object of type %s", type(obj))
+                continue
+            serialized: Dict[str, Any] = {}
+            serializer(obj, serialized)
+            result.append(serialized)
+        self._queue = [] # Clear just in case
         return result
 
     def deserialize(self, data: Dict[str, Any]) -> Any:

--- a/toolsaf/core/serializer/model_serializer.py
+++ b/toolsaf/core/serializer/model_serializer.py
@@ -66,8 +66,8 @@ class SystemSerializer:
                 stack.extend(reversed(self._queue)) # Depth first
         return result
 
-    def serialize_set(self, obj_set: Set[Any]):
-        """FIXME"""
+    def serialize_set(self, obj_set: Set[Any]) -> List[Dict[str, Any]]:
+        """Serialize a given set of objects"""
         result = []
         for obj in obj_set:
             if not (serializer := self.serializer_map.get(type(obj))):


### PR DESCRIPTION
This PR adds basic tracking of changes made to a security statement through the use of our DSL. The `SystemBuilder` and `SystemSerializer` were also updated to provide support for the serialization of tracked changes.

Closes Issue #161 