### PR TITLE
Make deserialized security statements editable via the DSL

### DIFF
--- a/tests/serializers/test_edit_deserialized.py
+++ b/tests/serializers/test_edit_deserialized.py
@@ -1,0 +1,167 @@
+from typing import cast
+from tests.test_model import Setup
+from toolsaf.main import TLS, HTTP, DHCP, DNS, UDP, NTP, MQTT, TCP
+from toolsaf.common.address import Protocol, IPAddress, AddressAtNetwork, DNSName
+from toolsaf.core.serializer.model_serializer import SystemSerializer
+from toolsaf.core.address_ranges import NULL_PORT_RANGE, PortRange
+from toolsaf.core.model import Service, Connection
+from toolsaf.builder_backend import SystemBackend, HostBackend, ServiceBackend, SoftwareBackend, ConnectionBackend
+
+
+def _loaded():
+    system = Setup().system
+    system.network(ip_mask="10.0.0.0/16")
+    dev = system.device("Device 1").serve(HTTP, TLS).ip("10.0.0.5")
+    dev / DHCP / DNS
+    dev.software("FW").sbom(["libc"])
+
+    cloud = system.device("Cloud").serve(HTTP).dns("cloud.com")
+    dev >> cloud / HTTP
+
+    any_host = system.any("Services")
+    mdns = any_host / UDP(port=5353, administrative=True).multicast("224.1.1.1")
+    mdns.name("mDNS")
+    dev >> mdns
+    cloud >> any_host / UDP().ports(7001, 7002).broadcast()
+
+    system.ignore(file_type="testssl").properties("testssl:BREACH").at(dev / TLS).because("Testing")
+
+    s = SystemSerializer()
+    s.deserialize_list(s.serialize(system.system))
+    return SystemBackend.from_entity(s.model_map[""])
+
+
+def test_cache_population():
+    sb = _loaded()
+
+    # There should be no changes right after loading
+    assert len(sb._changes) == 0
+    # 1 system, 3 hosts, 7 services, 1 software, 3 connections
+    assert len(sb.backends_by_entity) == 15
+
+    assert "Device 1" in sb.hosts_by_name and sb.hosts_by_name["Device 1"] is not None
+    assert ("", NULL_PORT_RANGE, Protocol.TCP, 80) in sb.hosts_by_name["Device 1"].service_builders
+    assert ("", NULL_PORT_RANGE, Protocol.TCP, 443) in sb.hosts_by_name["Device 1"].service_builders
+    assert ("", NULL_PORT_RANGE, Protocol.UDP, 53) in sb.hosts_by_name["Device 1"].service_builders
+    assert ("", NULL_PORT_RANGE, Protocol.UDP, 67) in sb.hosts_by_name["Device 1"].service_builders
+    assert (AddressAtNetwork(IPAddress.new("10.0.0.5"), sb.system.get_default_network())) in sb.entity_by_address
+    assert "FW" in sb.hosts_by_name["Device 1"].sw and sb.hosts_by_name["Device 1"].sw["FW"] is not None
+    assert len(sb.hosts_by_name["Device 1"].sw) == 1
+
+    assert "Cloud" in sb.hosts_by_name and sb.hosts_by_name["Cloud"] is not None
+    assert ("", NULL_PORT_RANGE, Protocol.TCP, 80) in sb.hosts_by_name["Cloud"].service_builders
+    assert (AddressAtNetwork(DNSName("cloud.com"), sb.system.get_default_network())) in sb.entity_by_address
+    assert len(sb.hosts_by_name["Cloud"].sw) == 0
+
+    assert "Services" in sb.hosts_by_name and sb.hosts_by_name["Services"] is not None
+    assert ("224.1.1.1", NULL_PORT_RANGE, Protocol.UDP, 5353) in sb.hosts_by_name["Services"].service_builders
+    assert ("255.255.255.255", PortRange([(7001, 7001)])+PortRange([(7002, 7002)]), Protocol.UDP, -1) in sb.hosts_by_name["Services"].service_builders
+    assert len(sb.hosts_by_name["Services"].sw) == 0
+
+    assert len(sb.entity_by_address) == 2
+
+    assert "testssl" in sb.ignore_backend.ignore_rules.rules and sb.ignore_backend.ignore_rules.rules["testssl"] is not None
+
+
+def test_getting_by_system_address():
+    sb = _loaded()
+    # Device
+    assert isinstance(sb.get_backend("Device_1"), HostBackend)
+    assert isinstance(sb.get_backend("Device_1/tcp:80"), ServiceBackend)        # HTTP
+    assert isinstance(sb.get_backend("Device_1/tcp:443"), ServiceBackend)       # TLS
+    assert isinstance(sb.get_backend("Device_1/udp:53"), ServiceBackend)        # DNS
+    assert isinstance(sb.get_backend("Device_1/udp:67"), ServiceBackend)        # DHCP
+    assert isinstance(sb.get_backend("Device_1&software=FW"), SoftwareBackend)
+    # Cloud
+    assert isinstance(sb.get_backend("Cloud"), HostBackend)
+    assert isinstance(sb.get_backend("Cloud/tcp:80"), ServiceBackend)
+    # Services by the environment
+    assert isinstance(sb.get_backend("Services"), HostBackend)
+    assert isinstance(sb.get_backend("Services/udp:5353"), ServiceBackend)      # mDNS
+    assert isinstance(sb.get_backend("Services/udp:7001"), ServiceBackend)      # Broadcast 7001-7002
+    # Connections
+    assert isinstance(sb.get_backend("source=Device_1&target=Cloud/tcp:80"), ConnectionBackend)
+    assert isinstance(sb.get_backend("source=Device_1&target=Services/udp:5353"), ConnectionBackend)
+    assert isinstance(sb.get_backend("source=Cloud&target=Services/udp:7001"), ConnectionBackend)
+
+    assert sb.get_backend("Nonexistent") is None
+
+
+def test_duplication_protection():
+    sb = _loaded()
+    iot_system = sb.system
+
+    assert len(iot_system.children) == 3
+    assert len(sb.hosts_by_name["Device 1"].entity.children) == 4
+    assert len(sb.hosts_by_name["Device 1"].sw) == 1
+    assert len(sb.hosts_by_name["Device 1"].entity.connections) == 2
+    assert len(sb.hosts_by_name["Cloud"].entity.children) == 1
+    assert len(sb.hosts_by_name["Cloud"].entity.connections) == 2
+    assert len(sb.hosts_by_name["Services"].entity.children) == 2
+    assert len(sb.hosts_by_name["Services"].entity.connections) == 2
+
+    sb.device("Device 1").serve(HTTP, TLS) / DHCP / DNS
+    sb.device("Device 1").software("FW")
+    sb.backend("Cloud").serve(HTTP)
+    sb.any("Services")
+    sb.device("Device 1") >> sb.backend("Cloud") / HTTP
+    sb.backend("Cloud") >> sb.any("Services") / UDP().ports(7001, 7002).broadcast()
+
+    assert len(iot_system.children) == 3
+    assert len(sb.hosts_by_name["Device 1"].entity.children) == 4
+    assert len(sb.hosts_by_name["Device 1"].sw) == 1
+    assert len(sb.hosts_by_name["Device 1"].entity.connections) == 2
+    assert len(sb.hosts_by_name["Cloud"].entity.children) == 1
+    assert len(sb.hosts_by_name["Cloud"].entity.connections) == 2
+    assert len(sb.hosts_by_name["Services"].entity.children) == 2
+    assert len(sb.hosts_by_name["Services"].entity.connections) == 2
+
+
+def test_getter_rename_safety():
+    sb = _loaded()
+    b = cast(HostBackend, sb.get_backend("Device_1"))
+    for address in b.entity.addresses:
+        if address.is_tag():
+            address.tag = "Device_1_Renamed"
+    assert sb.get_backend("Device_1") is None
+    assert sb.get_backend("Device_1_Renamed") is b
+
+
+def test_dhcp_source_fixer_reattached():
+    system = Setup().system
+    system.device("Device 1") / DHCP / NTP
+    s = SystemSerializer()
+    s.deserialize_list(s.serialize(system.system))
+    sb = SystemBackend.from_entity(s.model_map[""])
+
+    dhcp = cast(ServiceBackend, sb.get_backend("Device_1/udp:67"))
+    assert dhcp.source_fixer is not None
+
+    ntp = cast(ServiceBackend, sb.get_backend("Device_1/udp:123"))
+    assert ntp.source_fixer is None
+
+
+def test_edit_deserialized_and_serialize():
+    sb = _loaded()
+    dev = cast(HostBackend, sb.get_backend("Device_1"))
+    cloud = cast(HostBackend, sb.get_backend("Cloud"))
+    assert len(sb._changes) == 0
+
+    dev.set_property("edited", "ok")
+    assert len(sb._changes) == 1
+    assert sb._changes.pop() is dev.entity
+
+    cloud.serve(MQTT)
+    assert len(sb._changes) == 1
+    assert isinstance(sb._changes.pop(), Service)
+
+    cloud >> dev / TCP(port=8888)
+    assert len(sb._changes) == 2
+    expected_types = {Service, Connection}
+    for entry in sb._changes:
+        assert type(entry) in expected_types
+        expected_types.remove(type(entry))
+    sb._changes.clear()
+
+    entities = SystemSerializer().serialize(sb.system)
+    assert len(entities) == 19

--- a/tests/test_software_backend.py
+++ b/tests/test_software_backend.py
@@ -10,13 +10,13 @@ from toolsaf.common.verdict import Verdict
 
 
 def test_sbom_no_input():
-    sb = SoftwareBackend(MagicMock(), "test")
+    sb = SoftwareBackend.new(MagicMock(), "test")
     with pytest.raises(ConfigurationException):
         sb.sbom()
 
 
 def test_sbom_components_list():
-    sb = SoftwareBackend(MagicMock(), "test")
+    sb = SoftwareBackend.new(MagicMock(), "test")
     sb.sbom(["c1", "c2"])
     assert len(sb.sw.components) == 2
     assert len(sb.sw.properties) == 2
@@ -29,7 +29,7 @@ def test_sbom_components_list():
 
 
 def test_sbom_file():
-    sb = SoftwareBackend(MagicMock(), "test")
+    sb = SoftwareBackend.new(MagicMock(), "test")
 
     with pytest.raises(ConfigurationException):
         sb.sbom(file_path="test.json") # No file found

--- a/toolsaf/builder_backend.py
+++ b/toolsaf/builder_backend.py
@@ -151,7 +151,7 @@ class SystemBackend(SystemBuilder):
             h = Host(self.system, name, tag=EntityTag.new(name))  # tag is not renamed, name can be
             h.description = description
             h.match_priority = 10
-            hb = HostBackend(h, self)
+            hb = HostBackend.new(h, self)
         self.changed(hb.entity)
         return hb
 
@@ -281,7 +281,7 @@ class NodeBackend(NodeBuilder):
             name = Software.default_name(self.entity)
         sb = self.sw.get(name)
         if sb is None:
-            sb = SoftwareBackend(self, name)
+            sb = SoftwareBackend.new(self, name)
             self.sw[name] = sb
         self.system.changed(sb.sw)
         return sb
@@ -332,12 +332,14 @@ class ServiceBackend(NodeBackend, ServiceBuilder):
         NodeBackend.__init__(self, service, host.system)
         ServiceBuilder.__init__(self, host.system)
         self.entity: Service = service
-        self.entity.match_priority = 10
-        self.entity.external_activity = host.entity.external_activity
         self.parent: HostBackend = host
         self.multicast_protocol: Optional[ProtocolConfigurer] = None  # in broadcast 'source' services
-        self.source_fixer: Optional[Callable[[
-            'HostBackend'], 'ServiceBackend']] = None
+        self.source_fixer: Optional[Callable[['HostBackend'], 'ServiceBackend']] = None
+
+    @classmethod
+    def from_entity(cls, host: 'HostBackend', service: Service) -> 'ServiceBackend':
+        """Create a service backend for a deserialized service"""
+        return cls(host, service)
 
     def type(self, value: ConnectionType) -> 'ServiceBackend':
         self.entity.con_type = value
@@ -403,12 +405,23 @@ class HostBackend(NodeBackend, HostBuilder):
         NodeBackend.__init__(self, entity, system)
         HostBuilder.__init__(self, system)
         self.entity: Host = entity
-        system.system.children.append(entity)
-        entity.status = Status.EXPECTED
         system.hosts_by_name[entity.name] = self
-        if DNSName.looks_like(entity.name):
-            self.name(entity.name)
         self.service_builders: Dict[Tuple[str, PortRange, Protocol, int], ServiceBackend] = {}
+
+    @classmethod
+    def new(cls, entity: Host, system: SystemBackend) -> 'HostBackend':
+        """New host backend"""
+        host_backend = cls(entity, system)
+        entity.status = Status.EXPECTED
+        system.system.children.append(entity)
+        if DNSName.looks_like(entity.name):
+            host_backend.name(entity.name)
+        return host_backend
+
+    @classmethod
+    def from_entity(cls, entity: Host, system: SystemBackend) -> 'HostBackend':
+        """Create a host backend for a deserialized host"""
+        return cls(entity, system)
 
     def hw(self, address: str) -> Self:
         self.new_address_(HWAddress.new(address))
@@ -537,14 +550,24 @@ class NetworkBackend(NetworkBuilder):
 class SoftwareBackend(SoftwareBuilder):
     """Software builder backend"""
 
-    def __init__(self, parent: NodeBackend, software_name: str) -> None:
+    def __init__(self, parent: NodeBackend, software: Software) -> None:
+        self.parent = parent
+        self.sw = software
+
+    @classmethod
+    def new(cls, parent: NodeBackend, software_name: str) -> 'SoftwareBackend':
+        """New software backend"""
         sw = Software.get_software(parent.entity, software_name)
         if sw is None:
             # all hosts have software
             sw = Software(parent.entity, software_name)
             parent.entity.add_component(sw)
-        self.sw: Software = sw
-        self.parent = parent
+        return cls(parent, sw)
+
+    @classmethod
+    def from_entity(cls, parent: NodeBackend, software: Software) -> 'SoftwareBackend':
+        """Create a software backend for a deserialized software"""
+        return cls(parent, software)
 
     def updates_from(self, source: Union[ConnectionBuilder, ServiceBuilder, HostBuilder]) -> Self:
         host = self.parent.entity
@@ -690,8 +713,12 @@ class ProtocolBackend:
             self.service_port = self.port_range.get_low_port()
             self.port_to_name = False
             self.service_name = f"{self.service_name}:{self.port_range.get_name()}"
-        s = ServiceBackend(parent,
-                           parent.new_service_(self.service_name, self.service_port if self.port_to_name else -1))
+        s = ServiceBackend(
+            parent,
+            parent.new_service_(self.service_name, self.service_port if self.port_to_name else -1)
+        )
+        s.entity.match_priority = 10
+        s.entity.external_activity = parent.entity.external_activity
         s.entity.host_type = self.host_type
         s.entity.con_type = self.con_type
         s.entity.port_range = self.port_range
@@ -765,6 +792,7 @@ class DHCPBackend(ProtocolBackend):
 
     def _create_service(self, parent: HostBackend) -> ServiceBackend:
         host_s = ServiceBackend(parent, DHCPService(parent.entity))
+        host_s.entity.match_priority = 10
         assert self.external_activity, "external activity was None"
         host_s.entity.external_activity = self.external_activity
 
@@ -792,6 +820,7 @@ class DNSBackend(ProtocolBackend):
         dns_s = DNSService(parent.entity)
         dns_s.captive_portal = self.captive_portal
         s = ServiceBackend(parent, dns_s)
+        s.entity.match_priority = 10
         assert self.external_activity, "external activity was None"
         s.entity.external_activity = self.external_activity
         return s

--- a/toolsaf/builder_backend.py
+++ b/toolsaf/builder_backend.py
@@ -57,6 +57,16 @@ class SystemBackend(SystemBuilder):
         self.ignore_backend = IgnoreRulesBackend()
         self._changes: Set[Entity | Network] = set()
 
+    @classmethod
+    def from_entity(cls, system: IoTSystem) -> 'SystemBackend':
+        """Create a system backend for a deserialized system"""
+        sb = cls()
+        sb.system = system
+        sb.backends_by_entity[system] = sb
+        sb.ignore_backend.ignore_rules = system.ignore_rules
+        sb._reconstruct_from_system()
+        return sb
+
     def network(self, subnet: str="", ip_mask: Optional[str] = None) -> 'NetworkBuilder':
         if subnet:
             nb = NetworkBackend(self, subnet)
@@ -222,14 +232,6 @@ class SystemBackend(SystemBuilder):
                 return backend
         return None
 
-    def get_host_backend(self, host_name: str) -> Optional['HostBackend']:
-        """Get host backend by host name"""
-        return self.hosts_by_name.get(host_name)
-
-    def host_backends(self) -> List['HostBackend']:
-        """Get all host backends"""
-        return list(self.hosts_by_name.values())
-
     def changed(self, entity: Entity | Network) -> None:
         """Add entity to changed set"""
         self._changes.add(entity)
@@ -245,6 +247,36 @@ class SystemBackend(SystemBuilder):
         self._changes = set()
         return result
 
+    def _reconstruct_from_system(self) -> None:
+        """Reconstruct backends from IoTSystem entities and populate bookkeeping"""
+        for h in self.system.get_hosts():
+            hb = HostBackend.from_entity(h, self)
+            hb.register_existing_addresses()
+            self._link_services_to_hosts(hb, h)
+            self._build_component_backends(hb)
+
+        for c in self.system.get_connections(relevant_only=False):
+            ends = (self.backends_by_entity[c.source], self.backends_by_entity[c.target])
+            self.backends_by_entity[c] = ConnectionBackend(c, ends)
+
+    def _link_services_to_hosts(self, hb: 'HostBackend', parent_entity: Addressable) -> None:
+        """Link ServiceBackends to HostBackends via service_builders"""
+        for child in parent_entity.children:
+            if not isinstance(child, Service):
+                continue
+            sb = ServiceBackend.from_entity(hb, child)
+            key = ProtocolBackend.service_key_from_entity(child)
+            hb.service_builders[key] = sb
+            self._link_services_to_hosts(hb, child)
+
+    def _build_component_backends(self, nb: 'NodeBackend') -> None:
+        """Build component backends and link to NodeBackend via .from_entity or __init__"""
+        for c in nb.entity.components:
+            if isinstance(c, Software):
+                SoftwareBackend.from_entity(nb, c)
+            elif isinstance(c, Cookies) and isinstance(nb, HostBackend):
+                CookieBackend(nb)
+
 
 class NodeBackend(NodeBuilder):
     """Node building backend"""
@@ -252,6 +284,7 @@ class NodeBackend(NodeBuilder):
     def __init__(self, entity: Addressable, system: SystemBackend) -> None:
         super().__init__(system)
         self.system: SystemBackend = system
+        self.system.backends_by_entity[entity] = self
         self.entity = entity
         self.parent: Optional[NodeBackend] = None
         self.sw: Dict[str, SoftwareBackend] = {}
@@ -340,6 +373,13 @@ class NodeBackend(NodeBuilder):
     def __repr__(self) -> str:
         return self.entity.__repr__()
 
+    def register_existing_addresses(self) -> None:
+        """Register existing addresses to SystemBackend bookkeeping"""
+        for address in self.entity.addresses:
+            if not address.is_tag():
+                for network in self.entity.get_networks_for(address):
+                    self.system.entity_by_address[AddressAtNetwork(address, network)] = self
+
 
 class ServiceBackend(NodeBackend, ServiceBuilder):
     """Service builder backend"""
@@ -355,7 +395,10 @@ class ServiceBackend(NodeBackend, ServiceBuilder):
     @classmethod
     def from_entity(cls, host: 'HostBackend', service: Service) -> 'ServiceBackend':
         """Create a service backend for a deserialized service"""
-        return cls(host, service)
+        sb = cls(host, service)
+        if isinstance(service, DHCPService):
+            sb.source_fixer = DHCPBackend.dhcp_client_source
+        return sb
 
     def type(self, value: ConnectionType) -> 'ServiceBackend':
         self.entity.con_type = value
@@ -539,6 +582,7 @@ class ConnectionBackend(ConnectionBuilder):
     def __init__(self, connection: Connection, ends: Tuple[NodeBackend, ServiceBackend]) -> None:
         self.connection = connection
         self.ends = ends
+        ends[0].system.backends_by_entity[connection] = self
 
     def logical_only(self) -> Self:
         self.connection.con_type = ConnectionType.LOGICAL
@@ -569,6 +613,7 @@ class SoftwareBackend(SoftwareBuilder):
     def __init__(self, parent: NodeBackend, software: Software) -> None:
         self.parent = parent
         self.sw = software
+        parent.system.backends_by_entity[software] = self
 
     @classmethod
     def new(cls, parent: NodeBackend, software_name: str) -> 'SoftwareBackend':
@@ -583,7 +628,9 @@ class SoftwareBackend(SoftwareBuilder):
     @classmethod
     def from_entity(cls, parent: NodeBackend, software: Software) -> 'SoftwareBackend':
         """Create a software backend for a deserialized software"""
-        return cls(parent, software)
+        sb = cls(parent, software)
+        parent.sw[software.name] = sb
+        return sb
 
     def updates_from(self, source: Union[ConnectionBuilder, ServiceBuilder, HostBuilder]) -> Self:
         host = self.parent.entity
@@ -651,6 +698,7 @@ class CookieBackend(CookieBuilder):
     def __init__(self, builder: HostBackend) -> None:
         self.builder = builder
         self.component = Cookies.cookies_for(builder.entity)
+        self.builder.system.backends_by_entity[self.component] = self
 
     def set(self, cookies: Dict[str, Tuple[str, str, str]]) -> Self:
         for name, p in cookies.items():
@@ -719,6 +767,22 @@ class ProtocolBackend:
             parent.use_data(SensitiveDataBackend(
                 parent.system, self.critical_parameter))
         return b
+
+    @staticmethod
+    def service_key_from_entity(service: Service) -> Tuple[str, PortRange, Protocol, int]:
+        """Build a key from service"""
+        protocol_and_port = None
+        for address in service.addresses:
+            protocol_and_port = address.get_protocol_port()
+            if protocol_and_port:
+                break
+        assert protocol_and_port, "Service must have an address with protocol and port"
+        transport, port = protocol_and_port
+        if service.port_range is not None or service.protocol in {Protocol.EAPOL, Protocol.ICMP}:
+            port = -1
+        port_range = service.port_range or NULL_PORT_RANGE
+        mc = service.multicast_target.get_parseable_value() if service.multicast_target else ""
+        return (mc, port_range, transport, port)
 
     def _create_service(self, parent: HostBackend) -> ServiceBackend:
         if self.port_range:
@@ -806,21 +870,24 @@ class DHCPBackend(ProtocolBackend):
         # DHCP requests go to broadcast, thus the reply looks like request
         self.external_activity = ExternalActivity.UNLIMITED
 
+    @staticmethod
+    def dhcp_client_source(host: 'HostBackend') -> ServiceBackend:
+        """Create a source fixer for DHCP"""
+        # DHCP client uses specific port 68 for requests
+        src = UDP(port=68, name="DHCP")
+        cs = host / src
+        cs.entity.host_type = HostType.ADMINISTRATIVE
+        cs.entity.con_type = ConnectionType.ADMINISTRATIVE
+        cs.entity.client_side = True
+        return cs
+
     def _create_service(self, parent: HostBackend) -> ServiceBackend:
         host_s = ServiceBackend(parent, DHCPService(parent.entity))
         host_s.entity.match_priority = 10
         assert self.external_activity, "external activity was None"
         host_s.entity.external_activity = self.external_activity
 
-        def create_source(host: HostBackend) -> ServiceBackend:
-            # DHCP client uses specific port 68 for requests
-            src = UDP(port=68, name="DHCP")
-            cs = host / src
-            cs.entity.host_type = HostType.ADMINISTRATIVE
-            cs.entity.con_type = ConnectionType.ADMINISTRATIVE
-            cs.entity.client_side = True
-            return cs
-        host_s.source_fixer = create_source
+        host_s.source_fixer = DHCPBackend.dhcp_client_source
         return host_s
 
 

--- a/toolsaf/builder_backend.py
+++ b/toolsaf/builder_backend.py
@@ -43,6 +43,10 @@ from toolsaf.diagram_visualizer import DiagramVisualizer
 from toolsaf.core.ignore_rules import IgnoreRules
 from toolsaf.core.uploader import Uploader
 
+Backend = Union[
+    'SystemBackend', 'NodeBackend', 'ConnectionBackend', 'ServiceBackend',
+    'SoftwareBackend', 'NetworkBackend', 'CookieBackend'
+]
 
 class SystemBackend(SystemBuilder):
     """System model builder"""
@@ -51,7 +55,7 @@ class SystemBackend(SystemBuilder):
         self.system = IoTSystem(name)
         self.hosts_by_name: Dict[str, 'HostBackend'] = {}
         self.entity_by_address: Dict[AddressAtNetwork, 'NodeBackend'] = {}
-        self.backends_by_entity: Dict[Entity, Any] = {}
+        self.backends_by_entity: Dict[Entity, Backend] = {}
         self.diagram = DiagramVisualizer(self)
         self.protocols: Dict[Any, 'ProtocolBackend'] = {}
         self.ignore_backend = IgnoreRulesBackend()
@@ -225,7 +229,7 @@ class SystemBackend(SystemBuilder):
         #             prop_v = Properties.AUTHENTICATION_DATA.value(explanation=exp)
         #             prop_v[0].set(s.properties, prop_v[1])
 
-    def get_backend(self, system_address: str) -> Optional[Any]:
+    def get_backend(self, system_address: str) -> Optional[Backend]:
         """Get entity backend by system address"""
         for entity, backend in self.backends_by_entity.items():
             if entity.get_system_address().get_parseable_value() == system_address:
@@ -273,7 +277,10 @@ class SystemBackend(SystemBuilder):
             self._build_component_backends(hb)
 
         for c in self.system.get_connections(relevant_only=False):
-            ends = (self.backends_by_entity[c.source], self.backends_by_entity[c.target])
+            ends = cast(
+                Tuple[NodeBackend, ServiceBackend],
+                (self.backends_by_entity[c.source], self.backends_by_entity[c.target])
+            )
             self.backends_by_entity[c] = ConnectionBackend(c, ends)
 
     def _link_services_to_hosts(self, hb: 'HostBackend', parent_entity: Addressable) -> None:

--- a/toolsaf/builder_backend.py
+++ b/toolsaf/builder_backend.py
@@ -3,10 +3,10 @@
 import argparse
 import ipaddress
 import logging
-import pathlib
 import sys
 import inspect
 import json
+from pathlib import Path
 
 from typing import Any, Callable, Dict, List, Optional, Self, Tuple, Union, cast, Set
 
@@ -246,6 +246,23 @@ class SystemBackend(SystemBuilder):
         result = serializer.serialize_set(self._changes)
         self._changes = set()
         return result
+
+    @staticmethod
+    def read_serialized_statement(file_path: Path) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+        """
+        Read serialized statement from given file path and return entities and events separately
+        """
+        serialized_statement = json.loads(file_path.read_text(encoding='utf-8'))
+        serializer_version = next(iter(serialized_statement))
+        records = serialized_statement[serializer_version]
+
+        split_index = next(
+            (idx for idx, entry in enumerate(records) if entry.get("type") == "source"),
+            len(records)
+        )
+        system_data = records[:split_index]
+        source_data = records[split_index:]
+        return system_data, source_data
 
     def _reconstruct_from_system(self) -> None:
         """Reconstruct backends from IoTSystem entities and populate bookkeeping"""
@@ -658,7 +675,7 @@ class SoftwareBackend(SoftwareBuilder):
             key = PropertyKey("component", c)
             self.sw.properties[key] = PropertyVerdictValue(Verdict.INCON)
 
-    def __sbom_from_file(self, statement_file_path: pathlib.Path, file_path: str) -> None:
+    def __sbom_from_file(self, statement_file_path: Path, file_path: str) -> None:
         try:
             with (statement_file_path / file_path).resolve().open("rb") as f:
                 for c in SPDXJson(f).read():
@@ -680,7 +697,7 @@ class SoftwareBackend(SoftwareBuilder):
         if components:
             self.__sbom_from_list(components)
         else:
-            statement_file_path = pathlib.Path(inspect.stack()[1].filename).parent
+            statement_file_path = Path(inspect.stack()[1].filename).parent
             self.__sbom_from_file(statement_file_path, file_path)
 
         return self
@@ -1175,13 +1192,13 @@ class SystemBackendRunner(SystemBackend):
                             help="File name for created diagram. Default is the system's name")
         parser.add_argument("-l", "--log", dest="log_level", choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
                             help="Set the logging level", default=None)
-        parser.add_argument("-W", "--write-statement", type=pathlib.Path,
+        parser.add_argument("-W", "--write-statement", type=Path,
                             help="Dump JSON serialized security statement to given file")
-        parser.add_argument("-R", "--read-statement", type=pathlib.Path,
+        parser.add_argument("-R", "--read-statement", type=Path,
                             help="Read JSON serialized security statement from file. Use only with Toolsaf main.py")
         parser.add_argument("-u", "--upload", action="store_true",
                             help="Upload statement.")
-        parser.add_argument("--key-path", type=pathlib.Path,
+        parser.add_argument("--key-path", type=Path,
                             help="Custom path to API key file")
         parser.add_argument("--insecure", action="store_true",
                             help="Allow insecure server connections")
@@ -1192,6 +1209,14 @@ class SystemBackendRunner(SystemBackend):
         logging.basicConfig(format='%(message)s', level=getattr(
             logging, args.log_level or 'INFO'))
         return args
+
+    @classmethod
+    def load(cls, file_path: str) -> 'SystemBackendRunner':
+        """Load a serialized security statement from a file"""
+        system_data, _ = cls.read_serialized_statement(Path(file_path))
+        serializer = SystemSerializer()
+        serializer.deserialize_list(system_data)
+        return cast('SystemBackendRunner', cls.from_entity(serializer.model_map[""]))
 
     def run(self, custom_arguments: Optional[List[str]] = None) -> None:
         """Model is ready, run the checks, return data for programmatic caller"""
@@ -1206,19 +1231,10 @@ class SystemBackendRunner(SystemBackend):
             assert len(self.system.children) == 0, "System is not empty"
 
             # Read serialized security statement
-            json_path = cast(pathlib.Path, args.read_statement)
+            json_path = cast(Path, args.read_statement)
 
             print(f"Reading security statement from {json_path}")
-            json_data = json.loads(json_path.read_text())
-            serializer_version = list(json_data.keys())[0]
-
-            records = json_data[serializer_version]
-            split_index = next(
-                (idx for idx, entry in enumerate(records) if entry.get("type") == "source"),
-                len(records)
-            )
-            system_data = json_data[serializer_version][:split_index]
-            event_data = json_data[serializer_version][split_index:]
+            system_data, event_data = self.read_serialized_statement(json_path)
 
             # Deserialize the security statement
             system_serializer = SystemSerializer()
@@ -1248,7 +1264,7 @@ class SystemBackendRunner(SystemBackend):
         # load file batches, if defined
         batch_import = BatchImporter(event_logger, label_filter=label_filter)
         for in_file in args.read or []:
-            batch_import.import_batch(pathlib.Path(in_file))
+            batch_import.import_batch(Path(in_file))
 
         if args.help_tools:
             # print help and exit

--- a/toolsaf/builder_backend.py
+++ b/toolsaf/builder_backend.py
@@ -51,6 +51,7 @@ class SystemBackend(SystemBuilder):
         self.system = IoTSystem(name)
         self.hosts_by_name: Dict[str, 'HostBackend'] = {}
         self.entity_by_address: Dict[AddressAtNetwork, 'NodeBackend'] = {}
+        self.backends_by_entity: Dict[Entity, Any] = {}
         self.diagram = DiagramVisualizer(self)
         self.protocols: Dict[Any, 'ProtocolBackend'] = {}
         self.ignore_backend = IgnoreRulesBackend()
@@ -213,6 +214,21 @@ class SystemBackend(SystemBuilder):
         #             exp = f"Authentication by {auth.name} (implicit)"
         #             prop_v = Properties.AUTHENTICATION_DATA.value(explanation=exp)
         #             prop_v[0].set(s.properties, prop_v[1])
+
+    def get_backend(self, system_address: str) -> Optional[Any]:
+        """Get entity backend by system address"""
+        for entity, backend in self.backends_by_entity.items():
+            if entity.get_system_address().get_parseable_value() == system_address:
+                return backend
+        return None
+
+    def get_host_backend(self, host_name: str) -> Optional['HostBackend']:
+        """Get host backend by host name"""
+        return self.hosts_by_name.get(host_name)
+
+    def host_backends(self) -> List['HostBackend']:
+        """Get all host backends"""
+        return list(self.hosts_by_name.values())
 
     def changed(self, entity: Entity | Network) -> None:
         """Add entity to changed set"""

--- a/toolsaf/main.py
+++ b/toolsaf/main.py
@@ -502,6 +502,13 @@ class Builder:
         return SystemBackendRunner(name)
 
     @classmethod
+    def load(cls, file_path: str) -> SystemBuilder:
+        """Load a serialized security statement from a file"""
+        # avoid circular import
+        from toolsaf.builder_backend import SystemBackendRunner  # pylint: disable=import-outside-toplevel
+        return SystemBackendRunner.load(file_path)
+
+    @classmethod
     def UDP(cls, source_hw: str, source_ip: str, port: int) -> 'FlowBuilder':  # pylint: disable=invalid-name
         """Create a new UDP flow"""
         return FlowBuilder("UDP", (HWAddress.new(source_hw), IPAddress.new(source_ip), port))


### PR DESCRIPTION
This PR adds support for editing a deserialized security statement using the DSL. 

Editing can be resumed by using `SystemBackend.from_entity(<iot_system>)` on the deserialized `IoTSystem` and by then obtaining relevant backends with `SystemBackend.get_backend("<system_address>")`.

The following modifications were made to support editing:
- Added a non-mutating backend creator classmethod `from_entity()` to `SystemBackend`, `HostBackend`, `ServiceBackend` and `SoftwareBackend`
- `SystemBackend.from_entity` iterates over all hosts, services, etc. and populates the bookkeeping structures `hosts_by_name`, `service_builders`, `sw` and `entity_by_address` to avoid duplication
- Added a new bookkeeping structure called `backends_by_entity`. It is used by `SystemBackend.get_backend()` when fetching backends by `system address`. Works even if entities get renamed
- `system = Builder.load("<file_path>")` can now be used to start editing a serialized security statement

Also added unit tests targeting this feature.