### PR TITLE
Turn SoftwareComponent into a NodeComponent with a Status and a Verdict

### DIFF
--- a/documentation/Tools.md
+++ b/documentation/Tools.md
@@ -228,6 +228,8 @@ Example metafile `00meta.json`:
 
 SPDX file import is tested with files downloaded from Black Duck service. You can also use open-source SBOM generators to create `.json` format SPDX files.
 
+**Note:** SPDX file must be renamed to match the SW name defined in your security statement. For example, if you want to add a SBOM to `Mobile App` the file name must be `Mobile App SW.json` (no underscores).
+
 ### Ssh-audit
 
 > 🌐 [Ssh-audit](https://github.com/jtesta/ssh-audit)

--- a/documentation/architecture/Adapters.md
+++ b/documentation/architecture/Adapters.md
@@ -43,7 +43,7 @@ Tool output applied to network nodes.
 
 NodeComponentTool applies tool output to node components.
 
-**Input file name:** Sample data files need to be named after components. For example, if we want to apply tool output to Mobile_App's SW component, the file name must be Mobile_App_SW + `data_file_suffix`
+**Input file name:** Sample data files need to be named after components. For example, if we want to apply tool output to Mobile_App's SW component, the file name must be Mobile App SW + `data_file_suffix` (no underscores)
 
 ---
 ## Writing new tool adapters

--- a/tests/adapters/test_shodan_scan.py
+++ b/tests/adapters/test_shodan_scan.py
@@ -156,7 +156,7 @@ def test_add_cpes_undeclared_component_fails():
 
     scan.add_cpes(["cpe:2.3:a:example:software:1.0"], service)
 
-    found = parent_sw.get_component("software")
+    found = parent_sw.get_component("software", "1.0")
     assert found is not None
     assert found.version == "1.0"
     assert found.status == Status.UNEXPECTED

--- a/tests/adapters/test_shodan_scan.py
+++ b/tests/adapters/test_shodan_scan.py
@@ -11,8 +11,10 @@ from toolsaf.main import ConfigurationException, HTTP
 from toolsaf.common.address import IPAddress, Protocol, EndpointAddress
 from toolsaf.common.verdict import Verdict
 from toolsaf.common.property import PropertyKey
+from toolsaf.common.basics import Status
 from toolsaf.common.traffic import ServiceScan
 from toolsaf.core.model import Service
+from toolsaf.core.components import Software
 from tests.test_model import Setup
 
 
@@ -121,35 +123,45 @@ def test_add_heartbleed(opts, exp_verdict, exp_comment):
     "cpe23, exp_product, exp_version",
     [
         ("cpe:2.3:a:example:software:1.0", "software", "1.0"),
-        ("cpe:2.3:a:example:software:", "software", None),
-        ("cpe:2.3:a:example:software", "software", None),
+        ("cpe:2.3:a:example:software:", "software", ""),
+        ("cpe:2.3:a:example:software", "software", ""),
         ("cpe:2.3:a:example:software:2.0:extra", "software", "2.0"),
     ]
 )
 def test_parse_cpe23(cpe23, exp_product, exp_version):
     scan = ShodanScan(Setup().get_system())
-    product, version = scan.parse_cpe23(cpe23)
-    assert product == exp_product
-    assert version == exp_version
+    sw = Software(MagicMock())
+    component = scan.parse_cpe23(sw, cpe23)
+    assert component.name == exp_product
+    assert component.version == exp_version
+    assert component.software == sw
 
 
-@pytest.mark.parametrize(
-    "cpe23, exp_verdict, exp_comment",
-    [
-        (["cpe:2.3:a:example:software:1.0"], Verdict.FAIL, ["v1.0, Shodan CPE 2.3"]),
-        (["cpe:2.3:a:example:software:1.0", "cpe:2.3:a:example:software2:2.0"], Verdict.FAIL, ["v1.0, Shodan CPE 2.3", "v2.0, Shodan CPE 2.3"]),
-        (["cpe:2.3:a:example:software3"], Verdict.PASS, ["Shodan CPE 2.3"]),
-    ]
-)
-def test_add_cpes(cpe23, exp_verdict, exp_comment):
+def test_add_cpes_declared_component_passes():
     scan, service, backend = _mock_system()
     backend.software("test sw").sbom(["software3"])
+    parent_sw = service.parent.components[0]
 
-    scan.add_cpes(cpe23, service)
-    for i, entry in enumerate(cpe23):
-        product, _ = scan.parse_cpe23(entry)
-        assert service.parent.components[0].properties[PropertyKey("component", product)].verdict == exp_verdict
-        assert service.parent.components[0].properties[PropertyKey("component", product)].explanation == exp_comment[i]
+    scan.add_cpes(["cpe:2.3:a:example:software3"], service)
+
+    declared = parent_sw.get_component("software3")
+    assert declared.status == Status.EXPECTED
+    assert declared.status_string() == "Expected/Pass"
+
+
+def test_add_cpes_undeclared_component_fails():
+    scan, service, backend = _mock_system()
+    backend.software("test sw").sbom(["software3"])
+    parent_sw = service.parent.components[0]
+
+    scan.add_cpes(["cpe:2.3:a:example:software:1.0"], service)
+
+    found = parent_sw.get_component("software")
+    assert found is not None
+    assert found.version == "1.0"
+    assert found.status == Status.UNEXPECTED
+    assert found.status_string() == "Unexpected/Fail"
+    assert parent_sw.get_component("software3").status_string() == "Expected"
 
 
 def test_process_file():

--- a/tests/adapters/test_spdx_reader.py
+++ b/tests/adapters/test_spdx_reader.py
@@ -94,8 +94,8 @@ def test_process_component():
     ])
 
     reader.process_component(sw, data, setup.get_inspector(), MagicMock())
-    assert sw.get_component("c1").status_string() == "Expected/Pass"
-    assert sw.get_component("c2").status_string() == "Expected/Pass"
+    assert sw.get_component("c1", "1.0").status_string() == "Expected/Pass"
+    assert sw.get_component("c2", "1.0").status_string() == "Expected/Pass"
 
 
 def test_process_component_in_statement_not_in_data():
@@ -108,7 +108,7 @@ def test_process_component_in_statement_not_in_data():
     data = _get_json_data(packages=[])
 
     reader.process_component(sw, data, setup.get_inspector(), MagicMock())
-    assert sw.get_component("c1").status_string() == "Expected/Fail"
+    assert sw.get_component("c1", "1.0").status_string() == "Expected/Fail"
 
 
 def test_process_component_not_in_statement_in_data():
@@ -122,6 +122,6 @@ def test_process_component_not_in_statement_in_data():
     ])
 
     reader.process_component(sw, data, setup.get_inspector(), MagicMock())
-    c1 = sw.get_component("c1")
+    c1 = sw.get_component("c1", "1.0")
     assert c1 is not None
     assert c1.status_string() == "Unexpected/Fail"

--- a/tests/adapters/test_spdx_reader.py
+++ b/tests/adapters/test_spdx_reader.py
@@ -6,9 +6,7 @@ from unittest.mock import MagicMock
 
 from toolsaf.adapters.spdx_reader import SPDXJson, SPDXReader
 from toolsaf.core.components import Software, SoftwareComponent
-from toolsaf.common.property import PropertyKey
 from toolsaf.main import ConfigurationException
-from toolsaf.common.verdict import Verdict
 from tests.test_model import Setup
 
 
@@ -87,8 +85,8 @@ def test_process_component():
     reader = SPDXReader(setup.get_system())
 
     sw = Software(MagicMock())
-    sw.get_or_create_component("c1", "1.0")
-    sw.get_or_create_component("c2", "1.0")
+    sw.components.append(SoftwareComponent(sw, "c1", "1.0"))
+    sw.components.append(SoftwareComponent(sw, "c2", "1.0"))
 
     data = _get_json_data(packages=[
         {"name": "c1", "versionInfo": "1.0"},
@@ -105,7 +103,7 @@ def test_process_component_in_statement_not_in_data():
     reader = SPDXReader(setup.get_system())
 
     sw = Software(MagicMock())
-    sw.get_or_create_component("c1", "1.0")
+    sw.components.append(SoftwareComponent(sw, "c1", "1.0"))
 
     data = _get_json_data(packages=[])
 

--- a/tests/adapters/test_spdx_reader.py
+++ b/tests/adapters/test_spdx_reader.py
@@ -29,7 +29,7 @@ def test_spdx_json_read():
         ]
         _write_spdx_json(packages, tmp)
 
-        components = SPDXJson(file=tmp).read()
+        components = SPDXJson(file=tmp).read(Software(MagicMock()))
         assert len(components) == 3
         assert components[0].name == packages[0]["name"]
         assert components[0].version == packages[0]["versionInfo"]
@@ -47,7 +47,7 @@ def test_spdx_json_read_apk_kludge():
         ]
         _write_spdx_json(packages, tmp)
 
-        components = SPDXJson(file=tmp).read()
+        components = SPDXJson(file=tmp).read(Software(MagicMock()))
         assert len(components) == 1
         assert components[0].name == packages[1]["name"]
         assert components[0].version == packages[1]["versionInfo"]
@@ -61,7 +61,7 @@ def test_spdx_json_read_incorrect_json():
         tmp.seek(0)
 
         with pytest.raises(ConfigurationException):
-            SPDXJson(file=tmp).read()
+            SPDXJson(file=tmp).read(Software(MagicMock()))
 
     with tempfile.NamedTemporaryFile(delete=True, mode="w+") as tmp:
         json.dump({
@@ -70,7 +70,7 @@ def test_spdx_json_read_incorrect_json():
         tmp.seek(0)
 
         with pytest.raises(ConfigurationException):
-            SPDXJson(file=tmp).read()
+            SPDXJson(file=tmp).read(Software(MagicMock()))
 
 
 def _get_json_data(packages: list[dict]) -> io.BytesIO:
@@ -87,8 +87,8 @@ def test_process_component():
     reader = SPDXReader(setup.get_system())
 
     sw = Software(MagicMock())
-    sw.components["c1"] = SoftwareComponent("c1", "1.0")
-    sw.components["c2"] = SoftwareComponent("c2", "1.0")
+    sw.get_or_create_component("c1", "1.0")
+    sw.get_or_create_component("c2", "1.0")
 
     data = _get_json_data(packages=[
         {"name": "c1", "versionInfo": "1.0"},
@@ -96,8 +96,8 @@ def test_process_component():
     ])
 
     reader.process_component(sw, data, setup.get_inspector(), MagicMock())
-    assert sw.properties[PropertyKey("component", "c1")].verdict == Verdict.PASS
-    assert sw.properties[PropertyKey("component", "c2")].verdict == Verdict.PASS
+    assert sw.get_component("c1").status_string() == "Expected/Pass"
+    assert sw.get_component("c2").status_string() == "Expected/Pass"
 
 
 def test_process_component_in_statement_not_in_data():
@@ -105,12 +105,12 @@ def test_process_component_in_statement_not_in_data():
     reader = SPDXReader(setup.get_system())
 
     sw = Software(MagicMock())
-    sw.components["c1"] = SoftwareComponent("c1", "1.0")
+    sw.get_or_create_component("c1", "1.0")
 
     data = _get_json_data(packages=[])
 
     reader.process_component(sw, data, setup.get_inspector(), MagicMock())
-    assert sw.properties[PropertyKey("component", "c1")].verdict == Verdict.FAIL
+    assert sw.get_component("c1").status_string() == "Expected/Fail"
 
 
 def test_process_component_not_in_statement_in_data():
@@ -124,4 +124,6 @@ def test_process_component_not_in_statement_in_data():
     ])
 
     reader.process_component(sw, data, setup.get_inspector(), MagicMock())
-    assert sw.properties[PropertyKey("component", "c1")].verdict == Verdict.FAIL
+    c1 = sw.get_component("c1")
+    assert c1 is not None
+    assert c1.status_string() == "Unexpected/Fail"

--- a/tests/serializers/test_model_serializer.py
+++ b/tests/serializers/test_model_serializer.py
@@ -252,10 +252,10 @@ def test_software_dto():
     setup = Setup()
     device = setup.system.device("Device 1")
     software = device.software("Test Software").sw
-    software.components = {
-        "tc": SoftwareComponent("test-component", "1.0"),
-        "tc2": SoftwareComponent("test-component2", "2.0"),
-    }
+    software.components = [
+        SoftwareComponent(software, "test-component", "1.0"),
+        SoftwareComponent(software, "test-component2", "2.0"),
+    ]
     software.permissions.add(MobilePermissions.CALLS.value)
 
     serializer = SystemSerializer()
@@ -268,8 +268,8 @@ def test_software_dto():
         "parent_address": "Device_1",
         "type": "sw",
         "components": [
-            {"key": "tc", "name": "test-component", "version": "1.0"},
-            {"key": "tc2", "name": "test-component2", "version": "2.0"},
+            {"name": "test-component", "version": "1.0", "status": "Expected"},
+            {"name": "test-component2", "version": "2.0", "status": "Expected"},
         ],
         "permissions": [MobilePermissions.CALLS.value]
     }
@@ -280,7 +280,8 @@ def test_software_dto():
 
     assert isinstance(new_software, Software)
     assert new_software.name == software.name
-    assert new_software.components == software.components
+    assert [(c.name, c.version, c.status) for c in new_software.components] == \
+           [(c.name, c.version, c.status) for c in software.components]
     assert new_software.permissions == software.permissions
     assert new_software.entity == new_host
 

--- a/tests/serializers/test_model_validation.py
+++ b/tests/serializers/test_model_validation.py
@@ -270,22 +270,21 @@ def test_node_component_dto_invalid_values():
 
 def _valid_software_component():
     return {
-        "key": "sw-key",
         "name": "Software",
         "version": "1.0",
+        "status": Status.EXPECTED.value,
     }
 
 
 def test_software_component_dto_invalid_values():
     key_values = [
-        ("key", ""),
-        ("key", "a"*101),
-        ("key", 123),
         ("name", ""),
         ("name", "a"*101),
         ("name", 123),
         ("version", "a"*101),
         ("version", 123),
+        ("status", "unknown"),
+        ("status", 1),
     ]
     _validate(_valid_software_component(), key_values, SoftwareComponentDTO)
 

--- a/tests/test_change_tracking.py
+++ b/tests/test_change_tracking.py
@@ -333,14 +333,14 @@ def test_add_sbom():
     assert len(serialized) == 1
     assert serialized[0]["type"] == "sw"
     assert {
-        "key": "sw1",
         "name": "sw1",
         "version": "",
+        "status": "Expected",
     } in serialized[0]["components"]
     assert {
-        "key": "sw2",
         "name": "sw2",
         "version": "",
+        "status": "Expected",
     } in serialized[0]["components"]
     assert serialized[0]["address"] == "Test_Device&software=Test_Device_SW"
     assert serialized[0]["parent_address"] == "Test_Device"

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -7,7 +7,7 @@ from toolsaf.common.verdict import Verdict
 from toolsaf.common.property import Properties, PropertyVerdictValue
 from toolsaf.main import HTTP, TLS
 from toolsaf.core.event_logger import EventLogger
-from toolsaf.common.basics import ConnectionType
+from toolsaf.common.basics import ConnectionType, Status
 from toolsaf.core.result import *
 from tests.test_model import Setup
 
@@ -268,6 +268,54 @@ def test_build_host_structure():
             "HTTP:80": {"srcs": ["@1", "@2"], "address": "", "verdict": "Expected"},
         }
     }
+
+
+def test_build_host_structure_software_components():
+    """Software components are nested under the software with their own status/verdict"""
+    setup = Setup()
+    report = Report(EventLogger(setup.get_inspector()))
+    report.show = "properties"
+    report._get_sources = MagicMock(return_value=[])
+
+    device = setup.system.device("Device")
+    sw = device.software("Device SW").sw
+    # Declared in Statement and found from SBOM by adapter -> Expected/Pass
+    declared = sw.get_or_create_component("openssl", "3.0.2")
+    declared.set_property(Properties.EXPECTED.verdict(Verdict.PASS))
+    # Found by adapter but not in Statement -> Unexpected/Fail
+    undeclared = sw.get_or_create_component("telnetd")
+    undeclared.status = Status.UNEXPECTED
+    undeclared.set_property(Properties.EXPECTED.verdict(Verdict.FAIL))
+
+    structure = report.build_host_structure(setup.system.system.get_hosts())
+
+    assert structure["Device"]["Device SW [Component]"] == {
+        "srcs": [], "address": "", "verdict": "Expected/Fail",
+        "openssl - 3.0.2": {"srcs": [], "address": "", "verdict": "Expected/Pass"},
+        "telnetd": {"srcs": [], "address": "", "verdict": "Unexpected/Fail"},
+    }
+
+
+def test_print_host_structure_software_components():
+    """Nested software components render with their own [verdict] tags"""
+    report = Report(EventLogger(Setup().get_inspector()))
+    structure = {
+        "Device": {
+            "srcs": [], "address": "Device", "verdict": "Expected/Fail",
+            "Device SW [Component]": {
+                "srcs": [], "address": "", "verdict": "Expected/Fail",
+                "openssl - 3.0.2": {"srcs": [], "address": "", "verdict": "Expected/Pass"},
+                "telnetd": {"srcs": [], "address": "", "verdict": "Unexpected/Fail"},
+            },
+        }
+    }
+
+    writer = _mock_writer()
+    report._print_host_structure(0, structure, writer, "│  ", False)
+
+    assert any("[Expected/Fail]" in line and "Device SW [Component]" in line for line in writer.output)
+    assert any("[Expected/Pass]" in line and "openssl - 3.0.2" in line for line in writer.output)
+    assert any("[Unexpected/Fail]" in line and "telnetd" in line for line in writer.output)
 
 
 def test_print_host_structure():

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -3,11 +3,12 @@ from unittest.mock import MagicMock
 from typing import List, Tuple, Dict
 from colored import Fore
 
+from toolsaf.main import HTTP, TLS
 from toolsaf.common.verdict import Verdict
 from toolsaf.common.property import Properties, PropertyVerdictValue
-from toolsaf.main import HTTP, TLS
-from toolsaf.core.event_logger import EventLogger
 from toolsaf.common.basics import ConnectionType, Status
+from toolsaf.core.event_logger import EventLogger
+from toolsaf.core.components import SoftwareComponent
 from toolsaf.core.result import *
 from tests.test_model import Setup
 
@@ -280,12 +281,13 @@ def test_build_host_structure_software_components():
     device = setup.system.device("Device")
     sw = device.software("Device SW").sw
     # Declared in Statement and found from SBOM by adapter -> Expected/Pass
-    declared = sw.get_or_create_component("openssl", "3.0.2")
-    declared.set_property(Properties.EXPECTED.verdict(Verdict.PASS))
+    sw.components.append(SoftwareComponent(sw, "openssl", "3.0.2"))
+
+    sw.components[0].set_property(Properties.EXPECTED.verdict(Verdict.PASS))
     # Found by adapter but not in Statement -> Unexpected/Fail
-    undeclared = sw.get_or_create_component("telnetd")
-    undeclared.status = Status.UNEXPECTED
-    undeclared.set_property(Properties.EXPECTED.verdict(Verdict.FAIL))
+    sw.components.append(SoftwareComponent(sw, "telnetd"))
+    sw.components[1].status = Status.UNEXPECTED
+    sw.components[1].set_property(Properties.EXPECTED.verdict(Verdict.FAIL))
 
     structure = report.build_host_structure(setup.system.system.get_hosts())
 

--- a/tests/test_software_backend.py
+++ b/tests/test_software_backend.py
@@ -19,13 +19,8 @@ def test_sbom_components_list():
     sb = SoftwareBackend.new(MagicMock(), "test")
     sb.sbom(["c1", "c2"])
     assert len(sb.sw.components) == 2
-    assert len(sb.sw.properties) == 2
-    assert sb.sw.properties[
-        PropertyKey("component", "c1")
-    ].verdict == Verdict.INCON
-    assert sb.sw.properties[
-        PropertyKey("component", "c2")
-    ].verdict == Verdict.INCON
+    assert sb.sw.get_component("c1") is not None
+    assert sb.sw.get_component("c2") is not None
 
 
 def test_sbom_file():
@@ -48,13 +43,5 @@ def test_sbom_file():
 
         sb.sbom(file_path=tmp.name)
         assert len(sb.sw.components) == 2
-        assert sb.sw.components["package-1"].version == "1.0"
-        assert sb.sw.components["package-2"].version == "2.1.0"
-
-        assert len(sb.sw.properties) == 2
-        assert sb.sw.properties[
-            PropertyKey("component", "package-1")
-        ].verdict == Verdict.INCON
-        assert sb.sw.properties[
-            PropertyKey("component", "package-2")
-        ].verdict == Verdict.INCON
+        assert sb.sw.get_component("package-1").version == "1.0"
+        assert sb.sw.get_component("package-2").version == "2.1.0"

--- a/tests/test_software_backend.py
+++ b/tests/test_software_backend.py
@@ -43,5 +43,5 @@ def test_sbom_file():
 
         sb.sbom(file_path=tmp.name)
         assert len(sb.sw.components) == 2
-        assert sb.sw.get_component("package-1").version == "1.0"
-        assert sb.sw.get_component("package-2").version == "2.1.0"
+        assert sb.sw.get_component("package-1", "1.0").version == "1.0"
+        assert sb.sw.get_component("package-2", "2.1.0").version == "2.1.0"

--- a/toolsaf/adapters/shodan_scan.py
+++ b/toolsaf/adapters/shodan_scan.py
@@ -14,6 +14,7 @@ from toolsaf.adapters.tools import SystemWideTool, IncorrectBatchFileExcpetion, 
 from toolsaf.core.model import IoTSystem, Service
 from toolsaf.core.components import Software, SoftwareComponent
 from toolsaf.core.event_interface import EventInterface, PropertyEvent
+from toolsaf.common.basics import Status
 from toolsaf.common.traffic import EvidenceSource, Evidence, ServiceScan
 from toolsaf.common.address import IPAddress, Protocol, EndpointAddress
 from toolsaf.common.property import Properties, PropertyKey
@@ -85,14 +86,15 @@ class ShodanScan(SystemWideTool):
             prop_event = PropertyEvent(self._evidence, service, key.verdict(verdict, comment))
             self._interface.property_update(prop_event)
 
-    def parse_cpe23(self, cpe23: str) -> Tuple[str, Optional[str]]:
-        """Extracts the product and version number (if included) from a given CPE 2.3 string.
-            CPE 2.3 parts are cpe:2.3:<part>:<vendor>:<product>:<version>:...
+    def parse_cpe23(self, parent_sw: Software, cpe23: str) -> SoftwareComponent:
+        """
+        Extracts the product and version number (if included) from a given CPE 2.3 string.
+        CPE 2.3 parts are cpe:2.3:<part>:<vendor>:<product>:<version>:...
         """
         components = cpe23.split(":")
         product = components[4]
-        version = components[5] if len(components) > 5 and components[5] else None
-        return product, version
+        version = components[5] if len(components) > 5 and components[5] else ""
+        return SoftwareComponent(parent_sw, product, version)
 
     def add_cpes(self, cpe23_items: List[str], service: Service) -> None:
         """Add Common Platform Enumeration info to SW component and assign verdict based on statement SBOM"""
@@ -100,15 +102,33 @@ class ShodanScan(SystemWideTool):
         assert parent, f"{service} parent was None"
         if len(parent.components) > 0:
             parent_sw = cast(Software, parent.components[0])
-            for entry in cpe23_items:
-                product, version = self.parse_cpe23(entry)
-                software = SoftwareComponent(product)
-                verdict = Verdict.PASS if software in parent_sw.components.values() else Verdict.FAIL
-                key = PropertyKey("component", product)
-                comment = f"v{version}, Shodan CPE 2.3" if version else "Shodan CPE 2.3"
-                self._interface.property_update(
-                    PropertyEvent(self._evidence, parent_sw, key.verdict(verdict, comment))
-                )
+            parent_sw.set_seen_now()
+
+            for cpe23 in cpe23_items:
+                found = self.parse_cpe23(parent_sw, cpe23)
+                existing = parent_sw.get_component(found.name)
+                explanation = f"version {found.version}, Shodan CPE 2.3" if found.version else "Shodan CPE 2.3"
+                if existing is not None:
+                    if existing.status == Status.EXPECTED:
+                        self._interface.property_update(PropertyEvent(
+                            self._evidence, existing, Properties.EXPECTED.verdict(Verdict.PASS, explanation)
+                        ))
+
+                elif not self.load_baseline:
+                    found.status = Status.UNEXPECTED
+                    parent_sw.components.append(found)
+                    if self.send_events:
+                        found.set_seen_now()
+                        self._interface.property_update(PropertyEvent(
+                            self._evidence, found,
+                            Properties.EXPECTED.verdict(Verdict.FAIL, explanation="Found by Shodan but not declared")
+                        ))
+
+                else:
+                    parent_sw.components.append(found)
+
+                # Components in the statement but not found in scans will be left with status EXPECTED and no verdict
+
 
     @handle_incorrect_batch_file
     def process_file(self, data: BufferedReader, file_name: str,

--- a/toolsaf/adapters/spdx_reader.py
+++ b/toolsaf/adapters/spdx_reader.py
@@ -67,11 +67,14 @@ class SPDXReader(NodeComponentTool):
                 ))
 
         for found in found_components:
-            existing = software.get_component(found.name)
+            existing = software.get_component(found.name, found.version)
             if existing and self.send_events:
                 interface.property_update(PropertyEvent(
                     evidence, existing, Properties.EXPECTED.verdict(Verdict.PASS)
                 ))
+
+            elif self.load_baseline and not existing:
+                software.components.append(found)
 
             else:
                 if not self.load_baseline:

--- a/toolsaf/adapters/spdx_reader.py
+++ b/toolsaf/adapters/spdx_reader.py
@@ -8,10 +8,11 @@ from toolsaf.main import ConfigurationException
 from toolsaf.core.components import Software, SoftwareComponent
 from toolsaf.core.event_interface import PropertyEvent, EventInterface
 from toolsaf.core.model import IoTSystem, NodeComponent
-from toolsaf.common.property import Properties, PropertyKey
 from toolsaf.adapters.tools import NodeComponentTool
+from toolsaf.common.basics import Status
 from toolsaf.common.traffic import EvidenceSource, Evidence
 from toolsaf.common.verdict import Verdict
+from toolsaf.common.property import Properties
 
 
 class SPDXJson:
@@ -19,7 +20,7 @@ class SPDXJson:
     def __init__(self, file: BufferedReader) -> None:
         self.file = json.load(file)
 
-    def read(self) -> list[SoftwareComponent]:
+    def read(self, software: Software) -> list[SoftwareComponent]:
         """Read list of SoftwareComponents"""
         components = []
         try:
@@ -30,7 +31,7 @@ class SPDXJson:
                     continue # NOTE A kludge to clean away opened APK itself
                 if "property 'version'" in version:
                     version = ""  # NOTE: Kludging a bug in BlackDuck
-                components.append(SoftwareComponent(name, version))
+                components.append(SoftwareComponent(software, name, version))
             return components
         except KeyError as e:
             raise ConfigurationException(f"Field {e} missing from SPDX JSON") from e
@@ -45,36 +46,41 @@ class SPDXReader(NodeComponentTool):
     def filter_component(self, component: NodeComponent) -> bool:
         return isinstance(component, Software)
 
-    def process_component(self, component: NodeComponent, data_file: BufferedReader, interface: EventInterface,
-                       source: EvidenceSource) -> None:
+    def process_component(
+        self, component: NodeComponent, data_file: BufferedReader, interface: EventInterface,
+        source: EvidenceSource
+    ) -> None:
         software = cast(Software, component)
         evidence = Evidence(source)
-        properties = set()
 
-        components = SPDXJson(data_file).read()
-        for c in software.components.values():
-            if c not in components and self.send_events:
-                key = PropertyKey("component", c.name)
-                ev = PropertyEvent(evidence, software, key.verdict(Verdict.FAIL, explanation=f"{c.name} {c.version}"))
-                interface.property_update(ev)
-
-        for c in components:
-            key = PropertyKey("component", c.name)
-            properties.add(key)
-            old_sc = software.components.get(c.name)
-            verdict = Verdict.PASS
-
-            if self.load_baseline:
-                software.components[c.name] = c
-
-            if not old_sc and not self.load_baseline:
-                verdict = Verdict.FAIL
-                software.components[c.name] = c
-
-            if self.send_events:
-                ev = PropertyEvent(evidence, software, key.verdict(verdict, explanation=f"{c.name} {c.version}"))
-                interface.property_update(ev)
+        found_components = SPDXJson(data_file).read(software)
+        found_names = {c.name for c in found_components}
 
         if self.send_events:
-            ev = PropertyEvent(evidence, software, Properties.COMPONENTS.value_set(properties))
-            interface.property_update(ev)
+            software.set_seen_now()
+
+        for stated in software.components:
+            if stated.name not in found_names and self.send_events:
+                interface.property_update(PropertyEvent(
+                    evidence, stated,
+                    Properties.EXPECTED.verdict(Verdict.FAIL, explanation="Component not found in SBOM")
+                ))
+
+        for found in found_components:
+            existing = software.get_component(found.name)
+            if existing and self.send_events:
+                interface.property_update(PropertyEvent(
+                    evidence, existing, Properties.EXPECTED.verdict(Verdict.PASS)
+                ))
+
+            else:
+                if not self.load_baseline:
+                    found.status = Status.UNEXPECTED
+                software.components.append(found)
+
+                if self.send_events:
+                    found.set_seen_now()
+                    interface.property_update(PropertyEvent(
+                        evidence, found,
+                        Properties.EXPECTED.verdict(Verdict.FAIL, explanation="Component in SBOM but not declared")
+                    ))

--- a/toolsaf/builder_backend.py
+++ b/toolsaf/builder_backend.py
@@ -676,9 +676,14 @@ class SoftwareBackend(SoftwareBuilder):
         self.sw.update_connections.extend(cs)
         return self
 
-    def __sbom_from_list(self, components: List[str]) -> None:
+    def __sbom_from_list(
+        self, components: List[str | Tuple[str,str]]
+    ) -> None:
         for c in components:
-            self.sw.components.append(SoftwareComponent(self.sw, c, version=""))
+            if isinstance(c, tuple):
+                self.sw.components.append(SoftwareComponent(self.sw, c[0], version=c[1]))
+            else:
+                self.sw.components.append(SoftwareComponent(self.sw, c, version=""))
 
     def __sbom_from_file(self, statement_file_path: Path, file_path: str) -> None:
         try:
@@ -688,9 +693,10 @@ class SoftwareBackend(SoftwareBuilder):
         except FileNotFoundError as e:
             raise ConfigurationException(f"Could not find SBOM file {e.filename}") from e
 
-    def sbom(self, components: Optional[List[str]]=None, file_path: str="") -> Self:
-        """Add an SBOM from given list or SPDX JSON file.
-           file_path is relative to statement"""
+    def sbom(
+        self, components: List[str | Tuple[str,str]] | None = None,
+        file_path: str=""
+    ) -> Self:
         if not components and not file_path:
             raise ConfigurationException("Provide either components list of file")
         if file_path and not file_path.endswith(".json"):

--- a/toolsaf/builder_backend.py
+++ b/toolsaf/builder_backend.py
@@ -678,18 +678,13 @@ class SoftwareBackend(SoftwareBuilder):
 
     def __sbom_from_list(self, components: List[str]) -> None:
         for c in components:
-            self.sw.components[c] = SoftwareComponent(c, version="")
-            key = PropertyKey("component", c)
-            self.sw.properties[key] = PropertyVerdictValue(Verdict.INCON)
+            self.sw.components.append(SoftwareComponent(self.sw, c, version=""))
 
     def __sbom_from_file(self, statement_file_path: Path, file_path: str) -> None:
         try:
             with (statement_file_path / file_path).resolve().open("rb") as f:
-                for c in SPDXJson(f).read():
-                    self.sw.components[c.name] = c
-                    key = PropertyKey("component", c.name)
-                    self.sw.properties[key] =\
-                        PropertyVerdictValue(Verdict.INCON, explanation=f"version {c.version}")
+                for c in SPDXJson(f).read(self.sw):
+                    self.sw.components.append(c)
         except FileNotFoundError as e:
             raise ConfigurationException(f"Could not find SBOM file {e.filename}") from e
 

--- a/toolsaf/core/components.py
+++ b/toolsaf/core/components.py
@@ -35,7 +35,6 @@ class Software(NodeComponent):
 
     def get_component(self, name: str, version: str="") -> SoftwareComponent | None:
         """Get a software component by name"""
-        #return next((c for c in self.components if c.name == name), None)
         return next((c for c in self.components if c.name == name and c.version == version), None)
 
     def __repr__(self) -> str:

--- a/toolsaf/core/components.py
+++ b/toolsaf/core/components.py
@@ -7,12 +7,21 @@ from toolsaf.core.model import IoTSystem, NodeComponent, Connection, NetworkNode
 from toolsaf.common.entity import Entity
 
 
+class SoftwareComponent(NodeComponent):
+    """Software component"""
+    def __init__(self, software: 'Software', name: str, version: str = "") -> None:
+        super().__init__(software.entity, name)
+        self.concept_name = "software-component"
+        self.software = software
+        self.version = version
+
+
 class Software(NodeComponent):
     """Software, firmware, etc. Each real host has one or more software components."""
     def __init__(self, entity: NetworkNode, name: str = "") -> None:
         super().__init__(entity, name if name else self.default_name(entity))
         self.concept_name = "software"
-        self.components: List['SoftwareComponent'] = []
+        self.components: List[SoftwareComponent] = []
         self.permissions: Set[str] = set()
         self.update_connections: List[Connection] = []
 
@@ -24,9 +33,10 @@ class Software(NodeComponent):
     def get_children(self) -> Iterable['Entity']:
         return self.components
 
-    def get_component(self, name: str) -> Optional['SoftwareComponent']:
+    def get_component(self, name: str, version: str="") -> SoftwareComponent | None:
         """Get a software component by name"""
-        return next((c for c in self.components if c.name == name), None)
+        #return next((c for c in self.components if c.name == name), None)
+        return next((c for c in self.components if c.name == name and c.version == version), None)
 
     def __repr__(self) -> str:
         return f"{self.name}"
@@ -86,15 +96,6 @@ class Cookies(NodeComponent):
         c = Cookies(entity)
         entity.add_component(c)
         return c
-
-
-class SoftwareComponent(NodeComponent):
-    """Software component"""
-    def __init__(self, software: Software, name: str, version: str = "") -> None:
-        super().__init__(software.entity, name)
-        self.concept_name = "software-component"
-        self.software = software
-        self.version = version
 
 
 class OperatingSystem(NodeComponent):

--- a/toolsaf/core/components.py
+++ b/toolsaf/core/components.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Iterable, List, Optional, Dict, Set
 
 from toolsaf.core.model import IoTSystem, NodeComponent, Connection, NetworkNode, Host, SensitiveData, Addressable
+from toolsaf.common.entity import Entity
 
 
 class Software(NodeComponent):
@@ -11,7 +12,7 @@ class Software(NodeComponent):
     def __init__(self, entity: NetworkNode, name: str = "") -> None:
         super().__init__(entity, name if name else self.default_name(entity))
         self.concept_name = "software"
-        self.components: Dict[str, SoftwareComponent] = {}
+        self.components: List['SoftwareComponent'] = []
         self.permissions: Set[str] = set()
         self.update_connections: List[Connection] = []
 
@@ -19,6 +20,21 @@ class Software(NodeComponent):
     def default_name(cls, entity: NetworkNode) -> str:
         """Default SW name"""
         return f"{entity.long_name()} SW"
+
+    def get_children(self) -> Iterable['Entity']:
+        return self.components
+
+    def get_component(self, name: str) -> Optional['SoftwareComponent']:
+        """Get a software component by name"""
+        return next((c for c in self.components if c.name == name), None)
+
+    def get_or_create_component(self, name: str, version: str="") -> 'SoftwareComponent':
+        """Get or create a software component by name"""
+        if (component := self.get_component(name)):
+            return component
+        component = SoftwareComponent(self, name, version)
+        self.components.append(component)
+        return component
 
     def __repr__(self) -> str:
         return f"{self.name}"
@@ -80,11 +96,13 @@ class Cookies(NodeComponent):
         return c
 
 
-@dataclass
-class SoftwareComponent:
+class SoftwareComponent(NodeComponent):
     """Software component"""
-    name: str
-    version: str = ""
+    def __init__(self, software: Software, name: str, version: str = "") -> None:
+        super().__init__(software.entity, name)
+        self.concept_name = "software-component"
+        self.software = software
+        self.version = version
 
 
 class OperatingSystem(NodeComponent):

--- a/toolsaf/core/components.py
+++ b/toolsaf/core/components.py
@@ -28,14 +28,6 @@ class Software(NodeComponent):
         """Get a software component by name"""
         return next((c for c in self.components if c.name == name), None)
 
-    def get_or_create_component(self, name: str, version: str="") -> 'SoftwareComponent':
-        """Get or create a software component by name"""
-        if (component := self.get_component(name)):
-            return component
-        component = SoftwareComponent(self, name, version)
-        self.components.append(component)
-        return component
-
     def __repr__(self) -> str:
         return f"{self.name}"
 

--- a/toolsaf/core/result.py
+++ b/toolsaf/core/result.py
@@ -11,8 +11,9 @@ from colored import Fore, Style
 from toolsaf.common.basics import ConnectionType
 from toolsaf.common.entity import Entity
 from toolsaf.common.verdict import Verdict
-from toolsaf.core.model import Host, Connection, Addressable, NodeComponent, IoTSystem
 from toolsaf.common.property import Properties, PropertyKey, PropertyVerdictValue
+from toolsaf.core.components import Software
+from toolsaf.core.model import Host, Connection, Addressable, NodeComponent, IoTSystem
 from toolsaf.core.event_logger import EventLogger
 
 
@@ -207,7 +208,13 @@ class Report:
                 structure[entity.name][child.name] = self._get_sub_structure(child)
 
             for component in entity.components:
-                structure[entity.name][component.name + " [Component]"] = self._get_sub_structure(component)
+                key = component.name + " [Component]"
+                structure[entity.name][key] = self._get_sub_structure(component)
+
+                if isinstance(component, Software):
+                    for sw_component in component.components:
+                        sub_key = sw_component.name + (f" - {sw_component.version}" if sw_component.version else "")
+                        structure[entity.name][key][sub_key] = self._get_sub_structure(sw_component)
 
         return structure
 

--- a/toolsaf/core/serializer/model_serializer.py
+++ b/toolsaf/core/serializer/model_serializer.py
@@ -244,10 +244,10 @@ class SystemSerializer:
         data.update({
             "type": "sw",
             "components": [{
-                "key": key,
                 "name": component.name,
-                "version": component.version
-            } for key, component in obj.components.items()],
+                "version": component.version,
+                "status": component.status.value
+            } for component in obj.components],
             "permissions": list(obj.permissions)
         })
 
@@ -497,19 +497,18 @@ class SoftwareDTO(NodeComponentDTO):
         model = Software(entity=model_map[self.parent_address], name=self.name)
         super().populate(model, model_map)
         for component_dto in self.components:
-            model.components[component_dto.key] = SoftwareComponent(
-                name=component_dto.name,
-                version=component_dto.version
-            )
+            component = SoftwareComponent(model, component_dto.name, component_dto.version)
+            component.status = component_dto.status
+            model.components.append(component)
         model.permissions = {p.value for p in self.permissions}
         return model
 
 
 class SoftwareComponentDTO(BaseDTO):
     """DTO for SoftwareComponent"""
-    key: NameType
     name: NameType
-    version: str = Field("", max_length=50)
+    version: str = Field("", max_length=100)
+    status: Status
 
 
 class CookieDTO(NodeComponentDTO):

--- a/toolsaf/main.py
+++ b/toolsaf/main.py
@@ -223,9 +223,12 @@ class SoftwareBuilder:
         """Update mechanism"""
         raise NotImplementedError()
 
-    def sbom(self, components: Optional[List[str]]=None, file_path: str="") -> Self:
-        """Add an SBOM from given list or SPDX JSON file.
-           file_path is relative to the statement"""
+    def sbom(self, components: List[str | Tuple[str,str]] | None =None, file_path: str="") -> Self:
+        """
+        Add an SBOM from given list or SPDX JSON file.
+        components can be [name, name (name, version), ...].
+        file_path is relative to the statement
+        """
         raise NotImplementedError()
 
 


### PR DESCRIPTION
This pull request converts the `SoftwareComponent` class from a `dataclass` to a child of the `NodeComponent` class. With this change `SoftwareComponents` will now have statuses and verdicts. Previously they only had a `PropertyKey` indicating whether or not they were found in tool data as well causing them to not be printed out without the `-s properties` or `-s all` command line arguments being used.

As an example of the updated output, you can expect to see something like this:
```
[Expected/Fail]      App
[Expected/Fail]       └──App SW [Component]
[Expected/Pass]         ├──component 1    # Defined in the statement and found in SBOM
[Expected/Fail]         ├──component 2    # Defined in the statement but not found in SBOM
[Unexpected/Fail]       └──component 3    # Found in SBOM but not defined in the statement
```

These changes affect the results of the `SPDXReader` and `ShodanScan` adapters. `SPDXReader` will now also take version numbers into account when verifying results.

Documentation has been updated to point out that `SPDXReader` and `NodeComponentTool` adapters in general require slightly different naming for tool data files.

Finally, the `components` parameter that can be provided to `software().sbom()` now accepts (`name`, `version`) tuples as input. So you could do something like this, e.g.:
```python
backend.software().sbom(["component 1", ("component 2", "1.0.2"), "component 3"])
```