### PR TITLE
Always display SBOM and mobile app permissions when running a statement

### DIFF
--- a/documentation/Tools.md
+++ b/documentation/Tools.md
@@ -228,6 +228,8 @@ Example metafile `00meta.json`:
 
 SPDX file import is tested with files downloaded from Black Duck service. You can also use open-source SBOM generators to create `.json` format SPDX files.
 
+**Note:** SPDX file must be renamed to match the SW name defined in your security statement. For example, if you want to add a SBOM to `Mobile App` the file name must be `Mobile App SW.json` (no underscores).
+
 ### Ssh-audit
 
 > 🌐 [Ssh-audit](https://github.com/jtesta/ssh-audit)

--- a/documentation/architecture/Adapters.md
+++ b/documentation/architecture/Adapters.md
@@ -43,7 +43,7 @@ Tool output applied to network nodes.
 
 NodeComponentTool applies tool output to node components.
 
-**Input file name:** Sample data files need to be named after components. For example, if we want to apply tool output to Mobile_App's SW component, the file name must be Mobile_App_SW + `data_file_suffix`
+**Input file name:** Sample data files need to be named after components. For example, if we want to apply tool output to Mobile_App's SW component, the file name must be Mobile App SW + `data_file_suffix` (no underscores).
 
 ---
 ## Writing new tool adapters

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -4,7 +4,7 @@ from typing import List, Tuple, Dict
 from colored import Fore
 
 from toolsaf.common.verdict import Verdict
-from toolsaf.common.property import Properties, PropertyVerdictValue
+from toolsaf.common.property import Properties, PropertyKey, PropertyVerdictValue
 from toolsaf.main import HTTP, TLS
 from toolsaf.core.event_logger import EventLogger
 from toolsaf.common.basics import ConnectionType
@@ -117,6 +117,19 @@ def test_get_sources(values: List, source_count: int, expected: List):
             {Properties.MITM: _get_pvv(Verdict.PASS), Properties.FUZZ: _get_pvv(Verdict.IGNORE)},
             ["properties", "ignored"],
             [(Properties.MITM, _get_pvv(Verdict.PASS)), (Properties.FUZZ, _get_pvv(Verdict.IGNORE))]
+        ),
+        (
+            {PropertyKey("component", "openssl"): _get_pvv(Verdict.INCON)},
+            [], [(PropertyKey("component", "openssl"), _get_pvv(Verdict.INCON))]
+        ),
+        (
+            {PropertyKey("permission", "LOCATION"): _get_pvv(Verdict.INCON)},
+            [], [(PropertyKey("permission", "LOCATION"), _get_pvv(Verdict.INCON))]
+        ),
+        # Components/permissions show while other non-FAIL properties stay hidden by default
+        (
+            {PropertyKey("component", "openssl"): _get_pvv(Verdict.PASS), Properties.MITM: _get_pvv(Verdict.PASS)},
+            [], [(PropertyKey("component", "openssl"), _get_pvv(Verdict.PASS))]
         )
     ]
 )

--- a/toolsaf/adapters/spdx_reader.py
+++ b/toolsaf/adapters/spdx_reader.py
@@ -45,8 +45,10 @@ class SPDXReader(NodeComponentTool):
     def filter_component(self, component: NodeComponent) -> bool:
         return isinstance(component, Software)
 
-    def process_component(self, component: NodeComponent, data_file: BufferedReader, interface: EventInterface,
-                       source: EvidenceSource) -> None:
+    def process_component(
+        self, component: NodeComponent, data_file: BufferedReader, interface: EventInterface,
+        source: EvidenceSource
+    ) -> None:
         software = cast(Software, component)
         evidence = Evidence(source)
         properties = set()
@@ -55,25 +57,27 @@ class SPDXReader(NodeComponentTool):
         for c in software.components.values():
             if c not in components and self.send_events:
                 key = PropertyKey("component", c.name)
-                ev = PropertyEvent(evidence, software, key.verdict(Verdict.FAIL, explanation=f"{c.name} {c.version}"))
-                interface.property_update(ev)
+                interface.property_update(PropertyEvent(
+                    evidence, software,
+                    key.verdict(Verdict.FAIL,explanation="Declared in statement but not found in SBOM")
+                ))
 
         for c in components:
             key = PropertyKey("component", c.name)
             properties.add(key)
             old_sc = software.components.get(c.name)
-            verdict = Verdict.PASS
 
-            if self.load_baseline:
-                software.components[c.name] = c
-
-            if not old_sc and not self.load_baseline:
-                verdict = Verdict.FAIL
+            if self.load_baseline or not old_sc:
                 software.components[c.name] = c
 
             if self.send_events:
-                ev = PropertyEvent(evidence, software, key.verdict(verdict, explanation=f"{c.name} {c.version}"))
-                interface.property_update(ev)
+                if old_sc or self.load_baseline:
+                    interface.property_update(PropertyEvent(evidence, software, key.verdict(Verdict.PASS)))
+                else:
+                    interface.property_update(PropertyEvent(
+                        evidence, software,
+                        key.verdict(Verdict.FAIL, explanation="Declared in SBOM but not declared in statement")
+                    ))
 
         if self.send_events:
             ev = PropertyEvent(evidence, software, Properties.COMPONENTS.value_set(properties))

--- a/toolsaf/builder_backend.py
+++ b/toolsaf/builder_backend.py
@@ -701,8 +701,6 @@ class SoftwareBackend(SoftwareBuilder):
             raise ConfigurationException(f"Could not find SBOM file {e.filename}") from e
 
     def sbom(self, components: Optional[List[str]]=None, file_path: str="") -> Self:
-        """Add an SBOM from given list or SPDX JSON file.
-           file_path is relative to statement"""
         if not components and not file_path:
             raise ConfigurationException("Provide either components list of file")
         if file_path and not file_path.endswith(".json"):

--- a/toolsaf/core/result.py
+++ b/toolsaf/core/result.py
@@ -125,6 +125,11 @@ class Report:
 
         result = []
         for key, value in property_items:
+            # Always display SBOM (components) and mobile app permissions
+            if key.segments[0] in ["component", "permission"]:
+                result += [(key, value)]
+                continue
+
             if (is_instance:=isinstance(value, PropertyVerdictValue)) and (
                 value.verdict == Verdict.FAIL or
                 value.verdict == Verdict.IGNORE and "ignored" in self.show or

--- a/toolsaf/main.py
+++ b/toolsaf/main.py
@@ -224,8 +224,11 @@ class SoftwareBuilder:
         raise NotImplementedError()
 
     def sbom(self, components: Optional[List[str]]=None, file_path: str="") -> Self:
-        """Add an SBOM from given list or SPDX JSON file.
-           file_path is relative to the statement"""
+        """
+        Add an SBOM from given list or SPDX JSON file.
+        The components array does not accept version information.
+        file_path is relative to the statement
+        """
         raise NotImplementedError()
 
 


### PR DESCRIPTION
This PR is a reasonable way to address Issue #170.

With this change, the SBOM contents, provided in the statement, along with mobile application permissions will always be displayed when a statement is run. However, when no tool data is provided the verdict for those will still be `[Incon]`.

Explanations on SBOM failures have been made more descriptive.

Also updates documentation on `spdx` files.
