### PR TITLE
Improve CertMITMReader, update MQTT

### DIFF
--- a/tests/adapters/test_certmitm_reader.py
+++ b/tests/adapters/test_certmitm_reader.py
@@ -3,8 +3,8 @@ import zipfile
 
 from toolsaf.adapters.certmitm_reader import CertMITMReader
 from toolsaf.common.traffic import EvidenceSource
-from toolsaf.main import TLS, MQTT
-from toolsaf.common.property import Properties, PropertyKey
+from toolsaf.main import TLS, MQTT, SSH
+from toolsaf.common.property import PropertyKey
 from toolsaf.common.verdict import Verdict
 from tests.test_model import Setup
 
@@ -26,7 +26,8 @@ def test_process_file():
                                 ("certificates/BE3.com", io.BytesIO(b'test')),
                                 ("certificates/BE4.com", io.BytesIO(b'test')),
                                 ("certificates/BE5.com", io.BytesIO(b'test')),
-                                ("certificates/15.15.15.15_test.pem", io.BytesIO(b'test'))]):
+                                ("certificates/15.15.15.15_test.pem", io.BytesIO(b'test')),
+                                ("certificates/BE7.com", io.BytesIO(b'test'))]):
             zip_file.writestr(file_name, data.getvalue())
 
     setup = Setup()
@@ -40,27 +41,27 @@ def test_process_file():
     backend_4 = system.backend("BE4").ip("13.13.13.13").dns("BE4.com")
     backend_5 = system.backend("BE5").ip("14.14.14.14").dns("BE5.com")
     backend_6 = system.backend("BE6").ip("15.15.15.15")  # matched by IP-named certificate
+    backend_7 = system.backend("BE7").ip("16.16.16.16").dns("BE7.com")
 
-    device_1 >> backend_1 / TLS                     # Should fail
-    device_1 >> backend_2 / TLS(port=444)           # Should fail
-    device_1 >> backend_3 / TLS                     # Should pass
-    device_2 >> backend_3 / TLS                     # Should fail
-    device_1 >> backend_4 / MQTT(port=8883, tls=True)  # Encrypted MQTT, should pass
-    device_1 >> backend_5 / MQTT(port=1883)         # Plaintext MQTT, no verdict
-    device_1 >> backend_6 / TLS                     # Cert named by IP, should pass
+    device_1 >> backend_1 / TLS                         # Should fail
+    device_1 >> backend_2 / TLS(port=444)               # Should fail
+    device_1 >> backend_3 / TLS                         # Should pass
+    device_2 >> backend_3 / TLS                         # Should fail
+    device_1 >> backend_4 / MQTT(port=8883, tls=True)   # Encrypted MQTT, should pass
+    device_1 >> backend_5 / MQTT(port=1883)             # Plaintext MQTT, should fail
+    device_1 >> backend_6 / TLS                         # Cert named by IP, should pass
+    device_1 >> backend_7 / SSH                         # Encrypted but not TLS, no verdict
 
     reader = CertMITMReader(setup.get_system())
     source = EvidenceSource(name="")
     reader.process_file(zip_buffer, "", setup.get_inspector(), source)
 
     connections = system.system.get_connections()
-    assert len(connections) == 7
+    assert len(connections) == 8
 
     key = PropertyKey("certmitm")
-    # Connections (by source, backend) that were tested but not intercepted -> PASS
     should_pass = {("D1", "BE3"), ("D1", "BE4"), ("D1", "BE6")}
-    # Encryption unknown (plaintext) -> certmitm does not apply a verdict
-    no_verdict = {("D1", "BE5")}
+    no_verdict = {("D1", "BE5"), ("D1", "BE7")}
     for conn in connections:
         pair = (conn.source.name, conn.target.parent.name)
         if pair in no_verdict:

--- a/tests/adapters/test_certmitm_reader.py
+++ b/tests/adapters/test_certmitm_reader.py
@@ -25,7 +25,8 @@ def test_process_file():
                                 ("certificates/BE2.com", io.BytesIO(b'test')),
                                 ("certificates/BE3.com", io.BytesIO(b'test')),
                                 ("certificates/BE4.com", io.BytesIO(b'test')),
-                                ("certificates/BE5.com", io.BytesIO(b'test'))]):
+                                ("certificates/BE5.com", io.BytesIO(b'test')),
+                                ("certificates/15.15.15.15_test.pem", io.BytesIO(b'test'))]):
             zip_file.writestr(file_name, data.getvalue())
 
     setup = Setup()
@@ -38,6 +39,7 @@ def test_process_file():
     backend_3 = system.backend("BE3").ip("12.12.12.12").dns("BE3.com")
     backend_4 = system.backend("BE4").ip("13.13.13.13").dns("BE4.com")
     backend_5 = system.backend("BE5").ip("14.14.14.14").dns("BE5.com")
+    backend_6 = system.backend("BE6").ip("15.15.15.15")  # matched by IP-named certificate
 
     device_1 >> backend_1 / TLS                     # Should fail
     device_1 >> backend_2 / TLS(port=444)           # Should fail
@@ -45,17 +47,18 @@ def test_process_file():
     device_2 >> backend_3 / TLS                     # Should fail
     device_1 >> backend_4 / MQTT(port=8883, tls=True)  # Encrypted MQTT, should pass
     device_1 >> backend_5 / MQTT(port=1883)         # Plaintext MQTT, no verdict
+    device_1 >> backend_6 / TLS                     # Cert named by IP, should pass
 
     reader = CertMITMReader(setup.get_system())
     source = EvidenceSource(name="")
     reader.process_file(zip_buffer, "", setup.get_inspector(), source)
 
     connections = system.system.get_connections()
-    assert len(connections) == 6
+    assert len(connections) == 7
 
     key = PropertyKey("certmitm")
     # Connections (by source, backend) that were tested but not intercepted -> PASS
-    should_pass = {("D1", "BE3"), ("D1", "BE4")}
+    should_pass = {("D1", "BE3"), ("D1", "BE4"), ("D1", "BE6")}
     # Encryption unknown (plaintext) -> certmitm does not apply a verdict
     no_verdict = {("D1", "BE5")}
     for conn in connections:

--- a/tests/adapters/test_certmitm_reader.py
+++ b/tests/adapters/test_certmitm_reader.py
@@ -3,7 +3,7 @@ import zipfile
 
 from toolsaf.adapters.certmitm_reader import CertMITMReader
 from toolsaf.common.traffic import EvidenceSource
-from toolsaf.main import TLS
+from toolsaf.main import TLS, MQTT
 from toolsaf.common.property import Properties, PropertyKey
 from toolsaf.common.verdict import Verdict
 from tests.test_model import Setup
@@ -23,7 +23,9 @@ def test_process_file():
                                 ("certificates/", io.BytesIO(b'')),
                                 ("certificates/BE1.com", io.BytesIO(b'test')),
                                 ("certificates/BE2.com", io.BytesIO(b'test')),
-                                ("certificates/BE3.com", io.BytesIO(b'test'))]):
+                                ("certificates/BE3.com", io.BytesIO(b'test')),
+                                ("certificates/BE4.com", io.BytesIO(b'test')),
+                                ("certificates/BE5.com", io.BytesIO(b'test'))]):
             zip_file.writestr(file_name, data.getvalue())
 
     setup = Setup()
@@ -34,25 +36,34 @@ def test_process_file():
     backend_1 = system.backend("BE1").ip("10.10.10.10").dns("BE1.com")
     backend_2 = system.backend("BE2").ip("11.11.11.11").dns("BE2.com")
     backend_3 = system.backend("BE3").ip("12.12.12.12").dns("BE3.com")
+    backend_4 = system.backend("BE4").ip("13.13.13.13").dns("BE4.com")
+    backend_5 = system.backend("BE5").ip("14.14.14.14").dns("BE5.com")
 
-    device_1 >> backend_1 / TLS             # Should fail
-    device_1 >> backend_2 / TLS(port=444)   # Should fail
-    device_1 >> backend_3 / TLS             # Should pass
-    device_2 >> backend_3 / TLS             # Should fail
+    device_1 >> backend_1 / TLS                     # Should fail
+    device_1 >> backend_2 / TLS(port=444)           # Should fail
+    device_1 >> backend_3 / TLS                     # Should pass
+    device_2 >> backend_3 / TLS                     # Should fail
+    device_1 >> backend_4 / MQTT(port=8883, tls=True)  # Encrypted MQTT, should pass
+    device_1 >> backend_5 / MQTT(port=1883)         # Plaintext MQTT, no verdict
 
     reader = CertMITMReader(setup.get_system())
     source = EvidenceSource(name="")
     reader.process_file(zip_buffer, "", setup.get_inspector(), source)
 
-    assert len(system.system.get_connections()) == 4
+    connections = system.system.get_connections()
+    assert len(connections) == 6
 
-    expected_sources = ["D1"]*3 + ["D2"]
-    expected_targets = ["BE1", "BE2", "BE3", "BE3"]
-    for i, conn in enumerate(system.system.get_connections()):
-        assert conn.source.name == expected_sources[i] and conn.target.parent.name == expected_targets[i]
-        if conn.source.name == "D1" and conn.target.parent.name == "BE3":
-            # No fail
-            assert conn.properties[PropertyKey("certmitm")].verdict == Verdict.PASS
+    key = PropertyKey("certmitm")
+    # Connections (by source, backend) that were tested but not intercepted -> PASS
+    should_pass = {("D1", "BE3"), ("D1", "BE4")}
+    # Encryption unknown (plaintext) -> certmitm does not apply a verdict
+    no_verdict = {("D1", "BE5")}
+    for conn in connections:
+        pair = (conn.source.name, conn.target.parent.name)
+        if pair in no_verdict:
+            assert key not in conn.properties
+        elif pair in should_pass:
+            assert conn.properties[key].verdict == Verdict.PASS
         else:
-            assert conn.properties[PropertyKey("certmitm")].verdict == Verdict.FAIL
+            assert conn.properties[key].verdict == Verdict.FAIL
 

--- a/tests/test_other_protocols.py
+++ b/tests/test_other_protocols.py
@@ -2,9 +2,9 @@ from toolsaf.common.address import EndpointAddress, HWAddress, Protocol, HWAddre
 from toolsaf.common.verdict import Verdict
 from toolsaf.builder_backend import SystemBackend
 from toolsaf.core.inspector import Inspector
-from toolsaf.main import ICMP, UDP, ARP, EAPOL
+from toolsaf.main import ICMP, UDP, ARP, EAPOL, MQTT
 from toolsaf.common.traffic import IPFlow, EthernetFlow, NO_EVIDENCE
-from toolsaf.common.basics import Status
+from toolsaf.common.basics import Status, ConnectionType
 
 
 def test_icmp():
@@ -93,3 +93,14 @@ def test_eapol_name():
     assert s.entity.name == "EAPOL"
 
 
+def test_mqtt_tls():
+    sb = SystemBackend()
+    dev1 = sb.device().hw("01:02:03:04:05:06")
+
+    plain = dev1 / MQTT
+    assert plain.entity.protocol == Protocol.MQTT
+    assert plain.entity.con_type == ConnectionType.UNKNOWN
+
+    encrypted = dev1 / MQTT(port=8883, tls=True)
+    assert encrypted.entity.protocol == Protocol.MQTT
+    assert encrypted.entity.con_type == ConnectionType.ENCRYPTED

--- a/toolsaf/adapters/certmitm_reader.py
+++ b/toolsaf/adapters/certmitm_reader.py
@@ -5,10 +5,11 @@ from zipfile import ZipFile
 from io import BufferedReader
 from typing import Set, Tuple, Dict, Any, cast
 
-from toolsaf.common.address import HWAddresses, DNSName, Protocol
-from toolsaf.core.event_interface import EventInterface, PropertyEvent
 from toolsaf.adapters.tools import SystemWideTool
+from toolsaf.core.event_interface import EventInterface, PropertyEvent
 from toolsaf.core.model import IoTSystem, Host, Service
+from toolsaf.common.basics import ConnectionType
+from toolsaf.common.address import HWAddresses, DNSName
 from toolsaf.common.traffic import EvidenceSource, Evidence, IPFlow
 from toolsaf.common.property import PropertyKey
 from toolsaf.common.verdict import Verdict
@@ -64,7 +65,7 @@ class CertMITMReader(SystemWideTool):
                             if not isinstance(endpoint_connection.target, Service):
                                 continue
                             key = PropertyKey(self.tool_label)
-                            if endpoint_connection.target.protocol == Protocol.TLS \
+                            if endpoint_connection.con_type == ConnectionType.ENCRYPTED \
                             and key not in endpoint_connection.properties:
                                 ev = PropertyEvent(evidence, endpoint_connection, key.verdict(Verdict.PASS))
                                 interface.property_update(ev)

--- a/toolsaf/adapters/certmitm_reader.py
+++ b/toolsaf/adapters/certmitm_reader.py
@@ -9,7 +9,7 @@ from toolsaf.adapters.tools import SystemWideTool
 from toolsaf.core.event_interface import EventInterface, PropertyEvent
 from toolsaf.core.model import IoTSystem, Host, Service
 from toolsaf.common.basics import ConnectionType
-from toolsaf.common.address import HWAddresses, DNSName, AnyAddress
+from toolsaf.common.address import HWAddresses, DNSName, AnyAddress, Protocol
 from toolsaf.common.traffic import EvidenceSource, Evidence, IPFlow
 from toolsaf.common.property import PropertyKey
 from toolsaf.common.verdict import Verdict
@@ -68,6 +68,7 @@ class CertMITMReader(SystemWideTool):
                                 continue
                             key = PropertyKey(self.tool_label)
                             if endpoint_connection.con_type == ConnectionType.ENCRYPTED \
+                            and endpoint_connection.target.protocol != Protocol.SSH \
                             and key not in endpoint_connection.properties:
                                 ev = PropertyEvent(evidence, endpoint_connection, key.verdict(Verdict.PASS))
                                 interface.property_update(ev)

--- a/toolsaf/adapters/certmitm_reader.py
+++ b/toolsaf/adapters/certmitm_reader.py
@@ -9,7 +9,7 @@ from toolsaf.adapters.tools import SystemWideTool
 from toolsaf.core.event_interface import EventInterface, PropertyEvent
 from toolsaf.core.model import IoTSystem, Host, Service
 from toolsaf.common.basics import ConnectionType
-from toolsaf.common.address import HWAddresses, DNSName
+from toolsaf.common.address import HWAddresses, DNSName, AnyAddress
 from toolsaf.common.traffic import EvidenceSource, Evidence, IPFlow
 from toolsaf.common.property import PropertyKey
 from toolsaf.common.verdict import Verdict
@@ -27,7 +27,7 @@ class CertMITMReader(SystemWideTool):
         """Read log file"""
         evidence = Evidence(source)
         connections: Set[Tuple[str, str, str]] = set()
-        dns_names: Set[DNSName] = set()
+        seen_addresses: Set[AnyAddress] = set()
 
         # certmitm stores found issues in JSON format to errors.txt
         with ZipFile(data) as zip_file:
@@ -53,12 +53,14 @@ class CertMITMReader(SystemWideTool):
         with ZipFile(data) as zip_file:
             for file in zip_file.filelist:
                 if "certificates" in file.filename and not file.filename.endswith("/"):
-                    dns_name = DNSName(file.filename.split("/")[-1].split("_")[0])
-                    DNSName.validate(dns_name.name)
-                    if dns_name in dns_names:
+                    identifier = file.filename.split("/")[-1].split("_")[0]
+                    address = DNSName.name_or_ip(identifier)
+                    if isinstance(address, DNSName):
+                        DNSName.validate(identifier)
+                    if address in seen_addresses:
                         continue
-                    dns_names.add(dns_name)
-                    if (endpoint := self.system.find_endpoint(dns_name)):
+                    seen_addresses.add(address)
+                    if (endpoint := self.system.find_endpoint(address)):
                         if not isinstance(endpoint, Host):
                             continue
                         for endpoint_connection in endpoint.connections:

--- a/toolsaf/builder_backend.py
+++ b/toolsaf/builder_backend.py
@@ -1017,6 +1017,9 @@ class MQTTBackend(ProtocolBackend):
 
     def __init__(self, configurer: MQTT) -> None:
         super().__init__(Protocol.TCP, port=configurer.port, protocol=Protocol.MQTT, name=configurer.name)
+        if configurer.tls:
+            self.authentication = True
+            self.con_type = ConnectionType.ENCRYPTED
 
 
 class TLSBackend(ProtocolBackend):

--- a/toolsaf/main.py
+++ b/toolsaf/main.py
@@ -381,9 +381,10 @@ class IP(ProtocolConfigurer):
 
 class MQTT(ProtocolConfigurer):
     """MQTT Configurer"""
-    def __init__(self, port: int=1883) -> None:
+    def __init__(self, port: int=1883, tls: bool=False) -> None:
         ProtocolConfigurer.__init__(self, "MQTT")
         self.port = port
+        self.tls = tls
 
 
 class TLS(ProtocolConfigurer):


### PR DESCRIPTION
This PR addresses issue #185. It:
- Makes `CertmitmReader` determine whether to assign `PASS` based on connection type instead of protocol
- Makes `CertmitmReader` able to process result files starting with an IP address instead of a DNS name
- Makes it possible to mark MQTT as authenticated through the `tls` argument